### PR TITLE
Added netcore namespace

### DIFF
--- a/thrift/agent.thrift
+++ b/thrift/agent.thrift
@@ -24,6 +24,7 @@ include "jaeger.thrift"
 include "zipkincore.thrift"
 
 namespace java com.uber.jaeger.agent.thrift
+namespace netcore Jaeger.Thrift.Agent
 
 service Agent {
     oneway void emitZipkinBatch(1: list<zipkincore.Span> spans)

--- a/thrift/aggregation_validator.thrift
+++ b/thrift/aggregation_validator.thrift
@@ -19,6 +19,7 @@
 # THE SOFTWARE.
 
 namespace java com.uber.jaeger.thriftjava
+namespace netcore Jaeger.Thrift.Agent
 
 # ValidateTraceResponse returns ok when a trace has been written to redis.
 struct ValidateTraceResponse {

--- a/thrift/baggage.thrift
+++ b/thrift/baggage.thrift
@@ -19,6 +19,7 @@
 # THE SOFTWARE.
 
 namespace java com.uber.jaeger.thriftjava
+namespace netcore Jaeger.Thrift.Agent
 
 # BaggageRestriction contains the baggage key and the maximum length of the baggage value.
 struct BaggageRestriction {

--- a/thrift/crossdock/tracetest.thrift
+++ b/thrift/crossdock/tracetest.thrift
@@ -1,4 +1,5 @@
 namespace java com.uber.jaeger.crossdock.thrift
+namespace netcore Jaeger.Thrift.Crossdock
 
 enum Transport { HTTP, TCHANNEL, DUMMY }
 

--- a/thrift/dependency.thrift
+++ b/thrift/dependency.thrift
@@ -19,6 +19,7 @@
 # THE SOFTWARE.
 
 namespace java com.uber.jaeger.thriftjava
+namespace netcore Jaeger.Thrift.Agent
 
 struct DependencyLink {
   // parent service name (caller)

--- a/thrift/jaeger.thrift
+++ b/thrift/jaeger.thrift
@@ -19,6 +19,7 @@
 # THE SOFTWARE.
 
 namespace java com.uber.jaeger.thriftjava
+namespace netcore Jaeger.Thrift
 
 # TagType denotes the type of a Tag's value.
 enum TagType { STRING, DOUBLE, BOOL, LONG, BINARY }

--- a/thrift/sampling.thrift
+++ b/thrift/sampling.thrift
@@ -21,6 +21,7 @@
 # THE SOFTWARE.
 
 namespace java com.uber.jaeger.thrift.sampling_manager
+namespace netcore Jaeger.Thrift.Agent
 
 enum SamplingStrategyType { PROBABILISTIC, RATE_LIMITING }
 

--- a/thrift/zipkincore.thrift
+++ b/thrift/zipkincore.thrift
@@ -14,6 +14,7 @@
 namespace java com.twitter.zipkin.thriftjava
 #@namespace scala com.twitter.zipkin.thriftscala
 namespace rb Zipkin
+namespace netcore Jaeger.Thrift.Agent.Zipkin
 
 #************** Annotation.value **************
 /**


### PR DESCRIPTION
Added namespaces for netcore (C# with .netcore). Namespaces are:
1. ```Jaeger.Thrift```
2. ```Jaeger.Thrift.Agent```
3. ```Jaeger.Thrift.Agent.Zipkin```

I did not modify the build script because at the moment I'm using an [unofficial version of thrift that supports netcore](https://github.com/apache/thrift/pull/1379)