### PR TITLE
PHP namespace.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,9 @@ SWAGGER=docker run --rm -it -u ${shell id -u} -v "${PWD}:/go/src/${PROJECT_ROOT}
 THRIFT_GO_ARGS=thrift_import="github.com/apache/thrift/lib/go/thrift"
 THRIFT_PY_ARGS=new_style,tornado
 THRIFT_JAVA_ARGS=private-members
+THRIFT_PHP_ARGS=psr4
 
-THRIFT_GEN=--gen go:$(THRIFT_GO_ARGS) --gen py:$(THRIFT_PY_ARGS) --gen java:$(THRIFT_JAVA_ARGS) --gen js:node --gen cpp
+THRIFT_GEN=--gen go:$(THRIFT_GO_ARGS) --gen py:$(THRIFT_PY_ARGS) --gen java:$(THRIFT_JAVA_ARGS) --gen js:node --gen cpp --gen php:$(THRIFT_PHP_ARGS)
 THRIFT_CMD=$(THRIFT) -o /data $(THRIFT_GEN)
 
 THRIFT_FILES=agent.thrift jaeger.thrift sampling.thrift zipkincore.thrift crossdock/tracetest.thrift \

--- a/thrift/agent.thrift
+++ b/thrift/agent.thrift
@@ -17,6 +17,7 @@ include "zipkincore.thrift"
 
 namespace cpp jaegertracing.agent.thrift
 namespace java com.uber.jaeger.agent.thrift
+namespace php Jaeger.Thrift.Agent
 namespace netcore Jaeger.Thrift.Agent
 
 service Agent {

--- a/thrift/aggregation_validator.thrift
+++ b/thrift/aggregation_validator.thrift
@@ -14,6 +14,7 @@
 
 namespace cpp jaegertracing.thrift
 namespace java com.uber.jaeger.thriftjava
+namespace php Jaeger.Thrift.Agent
 namespace netcore Jaeger.Thrift.Agent
 
 # ValidateTraceResponse returns ok when a trace has been written to redis.

--- a/thrift/baggage.thrift
+++ b/thrift/baggage.thrift
@@ -14,6 +14,7 @@
 
 namespace cpp jaegertracing.thrift
 namespace java com.uber.jaeger.thriftjava
+namespace php Jaeger.Thrift.Agent
 namespace netcore Jaeger.Thrift.Agent
 
 # BaggageRestriction contains the baggage key and the maximum length of the baggage value.

--- a/thrift/crossdock/tracetest.thrift
+++ b/thrift/crossdock/tracetest.thrift
@@ -14,6 +14,7 @@
 
 namespace cpp jaegertracing.crossdock.thrift
 namespace java com.uber.jaeger.crossdock.thrift
+namespace php Jaeger.Thrift.Crossdock
 namespace netcore Jaeger.Thrift.Crossdock
 
 enum Transport { HTTP, TCHANNEL, DUMMY }

--- a/thrift/dependency.thrift
+++ b/thrift/dependency.thrift
@@ -14,6 +14,7 @@
 
 namespace cpp jaegertracing.thrift
 namespace java com.uber.jaeger.thriftjava
+namespace php Jaeger.Thrift.Agent
 namespace netcore Jaeger.Thrift.Agent
 
 struct DependencyLink {

--- a/thrift/jaeger.thrift
+++ b/thrift/jaeger.thrift
@@ -14,6 +14,7 @@
 
 namespace cpp jaegertracing.thrift
 namespace java com.uber.jaeger.thriftjava
+namespace php Jaeger.Thrift
 namespace netcore Jaeger.Thrift
 
 # TagType denotes the type of a Tag's value.

--- a/thrift/sampling.thrift
+++ b/thrift/sampling.thrift
@@ -14,6 +14,7 @@
 
 namespace cpp jaegertracing.sampling_manager.thrift
 namespace java com.uber.jaeger.thrift.sampling_manager
+namespace php Jaeger.Thrift.Agent
 namespace netcore Jaeger.Thrift.Agent
 
 enum SamplingStrategyType { PROBABILISTIC, RATE_LIMITING }

--- a/thrift/zipkincore.thrift
+++ b/thrift/zipkincore.thrift
@@ -15,6 +15,7 @@ namespace cpp twitter.zipkin.thrift
 namespace java com.twitter.zipkin.thriftjava
 #@namespace scala com.twitter.zipkin.thriftscala
 namespace rb Zipkin
+namespace php Jaeger.Thrift.Agent.Zipkin
 namespace netcore Jaeger.Thrift.Agent.Zipkin
 
 #************** Annotation.value **************


### PR DESCRIPTION
For now we can set only global php namespace in generator:
  thrift -r --gen php:psr4,nsglobal=Jaeger\\ThriftGen ./

This is not very usable because some classes from jaeger.thrift missing as they has same name as zipkincore.thrift (e.g. Span)
Simple solution is to specify namespace for particular type.