### PR TITLE
Revert "Incomplete span support (#50)"

### DIFF
--- a/thrift/jaeger.thrift
+++ b/thrift/jaeger.thrift
@@ -60,7 +60,6 @@ struct Span {
   9:  required i64           duration
   10: optional list<Tag>     tags
   11: optional list<Log>     logs
-  12: optional bool          incomplete   # indicates whether this is the final span or an intermediate (incomplete) span
 }
 
 # Process describes the traced process/service that emits spans.
@@ -75,7 +74,7 @@ struct Batch {
   2: required list<Span> spans
 }
 
-# BatchSubmitResponse is the response on submitting a batch.
+# BatchSubmitResponse is the response on submitting a batch. 
 struct BatchSubmitResponse {
     1: required bool ok   # The Collector's client is expected to only log (or emit a counter) when not ok equals false
 }


### PR DESCRIPTION
This reverts PR #50 that added `incomplete` flag.

I checked all Jaeger clients, none of them import IDL with that flag. The respective PR in the main repo (https://github.com/jaegertracing/jaeger/pull/979) is still WIP and requires some evidence of client work done to demonstrate the new functionality, therefore the IDL change was premature.
