### PR TITLE
chore(docs): fixed typos in thrift/zipkincore.thrift

### DIFF
--- a/thrift/zipkincore.thrift
+++ b/thrift/zipkincore.thrift
@@ -302,7 +302,7 @@ struct Span {
    * precise value possible. For example, gettimeofday or syncing nanoTime
    * against a tick of currentTimeMillis.
    *
-   * For compatibilty with instrumentation that precede this field, collectors
+   * For compatibility with instrumentation that precede this field, collectors
    * or span stores can derive this via Annotation.timestamp.
    * For example, SERVER_RECV.timestamp or CLIENT_SEND.timestamp.
    *
@@ -317,7 +317,7 @@ struct Span {
    * precise measurement decoupled from problems of clocks, such as skew or NTP
    * updates causing time to move backwards.
    *
-   * For compatibilty with instrumentation that precede this field, collectors
+   * For compatibility with instrumentation that precede this field, collectors
    * or span stores can derive this by subtracting Annotation.timestamp.
    * For example, SERVER_SEND.timestamp - SERVER_RECV.timestamp.
    *


### PR DESCRIPTION
Signed-off-by: Marc Bramaud <m.duboucheron@gmail.com>

## Which problem is this PR solving?
- typo in `thrift/zipkincore.thrift` docs.

I was pointed to this repo in jaegertracing/jaeger-client-go#475, hope this is the right source file :)
