### PR TITLE
Add ability to send data loss stats in Batch

### DIFF
--- a/thrift/jaeger.thrift
+++ b/thrift/jaeger.thrift
@@ -81,6 +81,7 @@ struct Process {
 struct ClientStats {
   1: required i64 fullQueueDroppedSpans
   2: required i64 tooLargeDroppedSpans
+  3: required i64 failedToEmitSpans
 }
 
 # Batch is a collection of spans reported out of process.

--- a/thrift/jaeger.thrift
+++ b/thrift/jaeger.thrift
@@ -79,8 +79,8 @@ struct Process {
 # to the Jaeger backend components (agent or collector) where those same metrics
 # can be re-emitted with standardized naming scheme.
 struct ClientStats {
-  1: required int64 fullQueueDroppedSpans
-  2: required int64 tooLargeDroppedSpans
+  1: required i64 fullQueueDroppedSpans
+  2: required i64 tooLargeDroppedSpans
 }
 
 # Batch is a collection of spans reported out of process.


### PR DESCRIPTION
## Which problem is this PR solving?

- https://github.com/jaegertracing/jaeger/issues/2005

## Short description of the changes

- Extend Batch to allow sending batch sequence number and some data loss stats
