### PR TITLE
Improve csharp support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
 .idea/
-gen-go/
-gen-java/
-gen-nodejs/
-gen-py.tornado/
-gen-cpp/
+gen-*/
 proto-gen-*/

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ PROTO_GEN_CSHARP_DIR ?= proto-gen-csharp
 PROTOC_WITHOUT_GRPC := $(PROTOC) \
 		$(PROTO_INCLUDES) \
 		--gogo_out=plugins=grpc,$(PROTO_GOGO_MAPPINGS):$(PWD)/${PROTO_GEN_GO_DIR} \
-		--java_out=proto-gen-java \
+		--java_out=${PROTO_GEN_JAVA_DIR} \
 		--python_out=${PROTO_GEN_PYTHON_DIR} \
 		--js_out=${PROTO_GEN_JS_DIR} \
 		--cpp_out=${PROTO_GEN_CPP_DIR} \

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ protocompile:
 
 PROTO_INCLUDES := \
 	-Iproto/api_v2 \
+	-Iproto \
 	-I/usr/include/github.com/gogo/protobuf
 # Remapping of std types to gogo types (must not contain spaces)
 PROTO_GOGO_MAPPINGS := $(shell echo \

--- a/proto/api_v2/model.proto
+++ b/proto/api_v2/model.proto
@@ -17,7 +17,6 @@ syntax="proto3";
 package jaeger.api_v2;
 
 import "gogoproto/gogo.proto";
-import "google/api/annotations.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/duration.proto";
 

--- a/thrift/agent.thrift
+++ b/thrift/agent.thrift
@@ -18,6 +18,7 @@ include "zipkincore.thrift"
 namespace cpp jaegertracing.agent.thrift
 namespace java io.jaegertracing.agent.thrift
 namespace php Jaeger.Thrift.Agent
+namespace netcore Jaeger.Thrift.Agent
 namespace netstd Jaeger.Thrift.Agent
 namespace lua jaeger.thrift.agent
 

--- a/thrift/agent.thrift
+++ b/thrift/agent.thrift
@@ -18,7 +18,7 @@ include "zipkincore.thrift"
 namespace cpp jaegertracing.agent.thrift
 namespace java io.jaegertracing.agent.thrift
 namespace php Jaeger.Thrift.Agent
-namespace netcore Jaeger.Thrift.Agent
+namespace netstd Jaeger.Thrift.Agent
 namespace lua jaeger.thrift.agent
 
 service Agent {

--- a/thrift/agent.thrift
+++ b/thrift/agent.thrift
@@ -18,7 +18,6 @@ include "zipkincore.thrift"
 namespace cpp jaegertracing.agent.thrift
 namespace java io.jaegertracing.agent.thrift
 namespace php Jaeger.Thrift.Agent
-namespace netcore Jaeger.Thrift.Agent
 namespace netstd Jaeger.Thrift.Agent
 namespace lua jaeger.thrift.agent
 

--- a/thrift/aggregation_validator.thrift
+++ b/thrift/aggregation_validator.thrift
@@ -15,7 +15,7 @@
 namespace cpp jaegertracing.thrift
 namespace java io.jaegertracing.thriftjava
 namespace php Jaeger.Thrift.Agent
-namespace netcore Jaeger.Thrift.Agent
+namespace netstd Jaeger.Thrift.Agent
 namespace lua jaeger.thrift.agent
 
 # ValidateTraceResponse returns ok when a trace has been written to redis.

--- a/thrift/aggregation_validator.thrift
+++ b/thrift/aggregation_validator.thrift
@@ -15,6 +15,7 @@
 namespace cpp jaegertracing.thrift
 namespace java io.jaegertracing.thriftjava
 namespace php Jaeger.Thrift.Agent
+namespace netcore Jaeger.Thrift.Agent
 namespace netstd Jaeger.Thrift.Agent
 namespace lua jaeger.thrift.agent
 

--- a/thrift/aggregation_validator.thrift
+++ b/thrift/aggregation_validator.thrift
@@ -15,7 +15,6 @@
 namespace cpp jaegertracing.thrift
 namespace java io.jaegertracing.thriftjava
 namespace php Jaeger.Thrift.Agent
-namespace netcore Jaeger.Thrift.Agent
 namespace netstd Jaeger.Thrift.Agent
 namespace lua jaeger.thrift.agent
 

--- a/thrift/baggage.thrift
+++ b/thrift/baggage.thrift
@@ -15,6 +15,7 @@
 namespace cpp jaegertracing.thrift
 namespace java io.jaegertracing.thriftjava
 namespace php Jaeger.Thrift.Agent
+namespace netcore Jaeger.Thrift.Agent
 namespace netstd Jaeger.Thrift.Agent
 namespace lua jaeger.thrift.agent
 

--- a/thrift/baggage.thrift
+++ b/thrift/baggage.thrift
@@ -15,7 +15,7 @@
 namespace cpp jaegertracing.thrift
 namespace java io.jaegertracing.thriftjava
 namespace php Jaeger.Thrift.Agent
-namespace netcore Jaeger.Thrift.Agent
+namespace netstd Jaeger.Thrift.Agent
 namespace lua jaeger.thrift.agent
 
 # BaggageRestriction contains the baggage key and the maximum length of the baggage value.

--- a/thrift/baggage.thrift
+++ b/thrift/baggage.thrift
@@ -15,7 +15,6 @@
 namespace cpp jaegertracing.thrift
 namespace java io.jaegertracing.thriftjava
 namespace php Jaeger.Thrift.Agent
-namespace netcore Jaeger.Thrift.Agent
 namespace netstd Jaeger.Thrift.Agent
 namespace lua jaeger.thrift.agent
 

--- a/thrift/crossdock/tracetest.thrift
+++ b/thrift/crossdock/tracetest.thrift
@@ -15,7 +15,7 @@
 namespace cpp jaegertracing.crossdock.thrift
 namespace java io.jaegertracing.crossdock.thrift
 namespace php Jaeger.Thrift.Crossdock
-namespace netcore Jaeger.Thrift.Crossdock
+namespace netstd Jaeger.Thrift.Crossdock
 
 enum Transport { HTTP, TCHANNEL, DUMMY }
 

--- a/thrift/dependency.thrift
+++ b/thrift/dependency.thrift
@@ -15,6 +15,7 @@
 namespace cpp jaegertracing.thrift
 namespace java io.jaegertracing.thriftjava
 namespace php Jaeger.Thrift.Agent
+namespace netcore Jaeger.Thrift.Agent
 namespace netstd Jaeger.Thrift.Agent
 namespace lua jaeger.thrift.agent
 

--- a/thrift/dependency.thrift
+++ b/thrift/dependency.thrift
@@ -15,7 +15,7 @@
 namespace cpp jaegertracing.thrift
 namespace java io.jaegertracing.thriftjava
 namespace php Jaeger.Thrift.Agent
-namespace netcore Jaeger.Thrift.Agent
+namespace netstd Jaeger.Thrift.Agent
 namespace lua jaeger.thrift.agent
 
 struct DependencyLink {

--- a/thrift/dependency.thrift
+++ b/thrift/dependency.thrift
@@ -15,7 +15,6 @@
 namespace cpp jaegertracing.thrift
 namespace java io.jaegertracing.thriftjava
 namespace php Jaeger.Thrift.Agent
-namespace netcore Jaeger.Thrift.Agent
 namespace netstd Jaeger.Thrift.Agent
 namespace lua jaeger.thrift.agent
 

--- a/thrift/jaeger.thrift
+++ b/thrift/jaeger.thrift
@@ -15,7 +15,7 @@
 namespace cpp jaegertracing.thrift
 namespace java io.jaegertracing.thriftjava
 namespace php Jaeger.Thrift
-namespace netcore Jaeger.Thrift
+namespace netstd Jaeger.Thrift
 namespace lua jaeger.thrift
 
 # TagType denotes the type of a Tag's value.

--- a/thrift/sampling.thrift
+++ b/thrift/sampling.thrift
@@ -15,7 +15,7 @@
 namespace cpp jaegertracing.sampling_manager.thrift
 namespace java io.jaegertracing.thrift.sampling_manager
 namespace php Jaeger.Thrift.Agent
-namespace netcore Jaeger.Thrift.Agent
+namespace netstd Jaeger.Thrift.Agent
 namespace lua jaeger.thrift.agent
 
 enum SamplingStrategyType { PROBABILISTIC, RATE_LIMITING }

--- a/thrift/sampling.thrift
+++ b/thrift/sampling.thrift
@@ -15,6 +15,7 @@
 namespace cpp jaegertracing.sampling_manager.thrift
 namespace java io.jaegertracing.thrift.sampling_manager
 namespace php Jaeger.Thrift.Agent
+namespace netcore Jaeger.Thrift.Agent
 namespace netstd Jaeger.Thrift.Agent
 namespace lua jaeger.thrift.agent
 

--- a/thrift/sampling.thrift
+++ b/thrift/sampling.thrift
@@ -15,7 +15,6 @@
 namespace cpp jaegertracing.sampling_manager.thrift
 namespace java io.jaegertracing.thrift.sampling_manager
 namespace php Jaeger.Thrift.Agent
-namespace netcore Jaeger.Thrift.Agent
 namespace netstd Jaeger.Thrift.Agent
 namespace lua jaeger.thrift.agent
 

--- a/thrift/throttling.thrift
+++ b/thrift/throttling.thrift
@@ -15,7 +15,7 @@
 namespace cpp jaegertracing.throttling.thrift
 namespace java io.jaegertracing.thrift.throttling
 namespace php Jaeger.Thrift.Agent
-namespace netcore Jaeger.Thrift.Agent
+namespace netstd Jaeger.Thrift.Agent
 
 // ThrottlingConfig describes the throttling behavior for a given service.
 // Throttling is controlled with a credit account per operation that is refilled

--- a/thrift/throttling.thrift
+++ b/thrift/throttling.thrift
@@ -15,6 +15,7 @@
 namespace cpp jaegertracing.throttling.thrift
 namespace java io.jaegertracing.thrift.throttling
 namespace php Jaeger.Thrift.Agent
+namespace netcore Jaeger.Thrift.Agent
 namespace netstd Jaeger.Thrift.Agent
 
 // ThrottlingConfig describes the throttling behavior for a given service.

--- a/thrift/throttling.thrift
+++ b/thrift/throttling.thrift
@@ -15,7 +15,6 @@
 namespace cpp jaegertracing.throttling.thrift
 namespace java io.jaegertracing.thrift.throttling
 namespace php Jaeger.Thrift.Agent
-namespace netcore Jaeger.Thrift.Agent
 namespace netstd Jaeger.Thrift.Agent
 
 // ThrottlingConfig describes the throttling behavior for a given service.

--- a/thrift/zipkincore.thrift
+++ b/thrift/zipkincore.thrift
@@ -16,6 +16,7 @@ namespace java com.twitter.zipkin.thriftjava
 #@namespace scala com.twitter.zipkin.thriftscala
 namespace rb Zipkin
 namespace php Jaeger.Thrift.Agent.Zipkin
+namespace netcore Jaeger.Thrift.Agent
 namespace netstd Jaeger.Thrift.Agent.Zipkin
 namespace lua jaeger.thrift.agent
 

--- a/thrift/zipkincore.thrift
+++ b/thrift/zipkincore.thrift
@@ -16,7 +16,7 @@ namespace java com.twitter.zipkin.thriftjava
 #@namespace scala com.twitter.zipkin.thriftscala
 namespace rb Zipkin
 namespace php Jaeger.Thrift.Agent.Zipkin
-namespace netcore Jaeger.Thrift.Agent.Zipkin
+namespace netstd Jaeger.Thrift.Agent.Zipkin
 namespace lua jaeger.thrift.agent
 
 

--- a/thrift/zipkincore.thrift
+++ b/thrift/zipkincore.thrift
@@ -16,7 +16,6 @@ namespace java com.twitter.zipkin.thriftjava
 #@namespace scala com.twitter.zipkin.thriftscala
 namespace rb Zipkin
 namespace php Jaeger.Thrift.Agent.Zipkin
-namespace netcore Jaeger.Thrift.Agent
 namespace netstd Jaeger.Thrift.Agent.Zipkin
 namespace lua jaeger.thrift.agent
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Fixes #62 
- Blocked by https://github.com/jaegertracing/docker-protobuf/pull/15

## Short description of the changes
* Thrift doesn't support netcore in 0.13.0 anymore
* C# can't be generated with 0.9.2, but 0.13.0 can't be used as blocked by https://github.com/ahawkins/docker-thrift/pull/22
  * Therefore only preparations made
* Removed unused import in model.proto to avoid warnings
* Improved Makefile to make it easier to read and maintain
* Generate annotation protos necessary in C# for reflection