### PR TITLE
Use Thrift 0.13.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
-THRIFT_VER=0.9.2
-THRIFT_IMG=thrift:$(THRIFT_VER)
+THRIFT_VER=0.13
+THRIFT_IMG=jaegertracing/thrift:$(THRIFT_VER)
 THRIFT=docker run -u $(shell id -u) -v "${PWD}:/data" $(THRIFT_IMG) thrift
 
 SWAGGER_VER=0.12.0
@@ -28,7 +28,7 @@ swagger-validate:
 	$(SWAGGER) validate ./swagger/zipkin2-api.yaml
 
 clean:
-	rm -rf gen-* || true
+	rm -rf *gen-* || true
 
 thrift:	thrift-image clean $(THRIFT_FILES)
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
-THRIFT_VER=0.13
-THRIFT_IMG=jaegertracing/thrift:$(THRIFT_VER)
+THRIFT_VER?=0.13
+THRIFT_IMG?=jaegertracing/thrift:$(THRIFT_VER)
 THRIFT=docker run -u $(shell id -u) -v "${PWD}:/data" $(THRIFT_IMG) thrift
 
 SWAGGER_VER=0.12.0


### PR DESCRIPTION
## Which problem is this PR solving?
- https://github.com/jaegertracing/jaeger/issues/1972
- https://github.com/uber/tchannel-go/issues/781
- https://github.com/jaegertracing/jaeger-client-csharp/issues/139
- https://github.com/jaegertracing/jaeger-idl/issues/62

## Which PRs is this blocked on?
- https://github.com/jaegertracing/jaeger-idl/pull/63
- https://github.com/jaegertracing/docker-protobuf/pull/15

## Short description of the changes
- The Go and C# clients need to upgrade Thrift to `0.13`. Go because of a inherited Prometheus dependency, C# because of strong naming assemblies. The current `jaeger-idl` only produces `0.9.2`. Right now, we have to manually adjust the `Makefile` to use the necessary version. There is no way to also use this as submodule.

I would like to check if other libraries need to stay on `0.9.2` for any reason or if we can upgrade this for all. If any have to stay on the old version, we might modify the Makefile to use different versions for the different clients.