### PR TITLE
Fix code generation issue for python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,10 @@ PROTOC_CS_INTERNAL := $(PROTOC) \
 		$(PROTO_INCLUDES) \
 		--csharp_out=internal_access,base_namespace:${PROTO_GEN_CSHARP_DIR}
 
+ PROTOC_PY_INTERNAL := $(PROTOC) \
+		$(PROTO_INCLUDES) \
+		--python_out=${PROTO_GEN_PYTHON_DIR}
+
 proto:
 	mkdir -p ${PROTO_GEN_GO_DIR} \
 		${PROTO_GEN_JAVA_DIR} \
@@ -110,6 +114,13 @@ proto:
 		protoc-gen-swagger/options/annotations.proto \
 		protoc-gen-swagger/options/openapiv2.proto \
 		gogoproto/gogo.proto
+
+	$(PROTOC_PY_INTERNAL) \
+		google/api/annotations.proto \
+		google/api/http.proto \
+		protoc-gen-swagger/options/annotations.proto \
+		protoc-gen-swagger/options/openapiv2.proto \
+			/gogo.proto
 
 proto-zipkin:
 	$(PROTOC_WITHOUT_GRPC) \


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Fixes https://github.com/jaegertracing/docker-protobuf/issues/24

## Short description of the changes
**proto-gen-python** can not be used because `google/api/annotations.proto`, `gogoproto/gogo.proto` and `protoc-gen-swagger/options/annotations.proto` are not created but required to use the `model` or `collector` generated files.

Update the Makefile to `generate google/api/annotations.proto`, `gogoproto/gogo.proto` and `protoc-gen-swagger/options/annotations.proto`
