### PR TITLE
Fix selector for grpc gateway in apiv3

### DIFF
--- a/proto/api_v3/query_service_http.yaml
+++ b/proto/api_v3/query_service_http.yaml
@@ -6,7 +6,7 @@ http:
   rules:
     - selector: jaeger.api_v3.QueryService.GetTrace
       get: /v3/traces/{trace_id}
-    - selector: jaeger.api_v3.QueryService.GetTraces
+    - selector: jaeger.api_v3.QueryService.FindTraces
       get: /v3/traces
     - selector: jaeger.api_v3.QueryService.GetServices
       get: /v3/services


### PR DESCRIPTION
This is a bug fix, without this the compilation for grp-gateway does not work