### PR TITLE
Document required fields in api_v3

### DIFF
--- a/proto/api_v3/query_service.proto
+++ b/proto/api_v3/query_service.proto
@@ -48,13 +48,13 @@ message TraceQueryParameters {
   // Attributes are matched against Span and Resource attributes.
   // At least one span in a trace must match all specified attributes.
   map<string, string> attributes = 3;
-  // Span min start time in. RFC-3339ns format. Required.
+  // Span min start time in. REST API uses RFC-3339ns format. Required.
   google.protobuf.Timestamp start_time_min = 4;
-  // Span max start time. RFC-3339ns format. Required.
+  // Span max start time. REST API uses RFC-3339ns format. Required.
   google.protobuf.Timestamp start_time_max = 5;
-  // Span min duration. Golang duration format. Required.
+  // Span min duration. REST API uses Golang's time format e.g. 10s. Required.
   google.protobuf.Duration duration_min = 6;
-  // Span max duration. Golang duration format. Required.
+  // Span max duration. REST API uses Golang's time format 10s. Required.
   google.protobuf.Duration duration_max = 7;
   // Maximum number of traces in the response.
   int32 num_traces = 8;

--- a/proto/api_v3/query_service.proto
+++ b/proto/api_v3/query_service.proto
@@ -48,13 +48,13 @@ message TraceQueryParameters {
   // Attributes are matched against Span and Resource attributes.
   // At least one span in a trace must match all specified attributes.
   map<string, string> attributes = 3;
-  // Span min start time.
+  // Span min start time in. RFC-3339ns format. Required.
   google.protobuf.Timestamp start_time_min = 4;
-  // Span max start time.
+  // Span max start time. RFC-3339ns format. Required.
   google.protobuf.Timestamp start_time_max = 5;
-  // Span min duration.
+  // Span min duration. Golang duration format. Required.
   google.protobuf.Duration duration_min = 6;
-  // Span max duration.
+  // Span max duration. Golang duration format. Required.
   google.protobuf.Duration duration_max = 7;
   // Maximum number of traces in the response.
   int32 num_traces = 8;

--- a/proto/api_v3/query_service.proto
+++ b/proto/api_v3/query_service.proto
@@ -52,9 +52,9 @@ message TraceQueryParameters {
   google.protobuf.Timestamp start_time_min = 4;
   // Span max start time. REST API uses RFC-3339ns format. Required.
   google.protobuf.Timestamp start_time_max = 5;
-  // Span min duration. REST API uses Golang's time format e.g. 10s. Required.
+  // Span min duration. REST API uses Golang's time format e.g. 10s.
   google.protobuf.Duration duration_min = 6;
-  // Span max duration. REST API uses Golang's time format e.g. 10s. Required.
+  // Span max duration. REST API uses Golang's time format e.g. 10s.
   google.protobuf.Duration duration_max = 7;
   // Maximum number of traces in the response.
   int32 num_traces = 8;

--- a/proto/api_v3/query_service.proto
+++ b/proto/api_v3/query_service.proto
@@ -54,7 +54,7 @@ message TraceQueryParameters {
   google.protobuf.Timestamp start_time_max = 5;
   // Span min duration. REST API uses Golang's time format e.g. 10s. Required.
   google.protobuf.Duration duration_min = 6;
-  // Span max duration. REST API uses Golang's time format 10s. Required.
+  // Span max duration. REST API uses Golang's time format e.g. 10s. Required.
   google.protobuf.Duration duration_max = 7;
   // Maximum number of traces in the response.
   int32 num_traces = 8;


### PR DESCRIPTION
Example query: 
```
curl -H "Content-Type: application/json" http://localhost:16686/v3/traces\?query.serviceName\=jaeger-query\&query.start_time_min\="2021-07-01T01:00:00Z"\&query.start_time_max\=2021-07-03T01:00:00Z\&query.duration_min\=0\&query.duration_max\=10s\&query.num_traces\=150000
```

Documenting this as it took me a while to realize which parameters are required and what is the format.