### PR TITLE
Add start and end timestamp args to GetTrace request

### DIFF
--- a/proto/api_v2/query.proto
+++ b/proto/api_v2/query.proto
@@ -40,6 +40,10 @@ message GetTraceRequest {
     (gogoproto.customtype) = "github.com/jaegertracing/jaeger/model.TraceID",
     (gogoproto.customname) = "TraceID"
   ];
+  // Optional. The start time to search trace ID.
+  google.protobuf.Timestamp start_time = 2;
+  // Optional. The end time to search trace ID.
+  google.protobuf.Timestamp end_time = 3;
 }
 
 message SpansResponseChunk {
@@ -54,6 +58,10 @@ message ArchiveTraceRequest {
     (gogoproto.customtype) = "github.com/jaegertracing/jaeger/model.TraceID",
     (gogoproto.customname) = "TraceID"
   ];
+  // Optional. The start time to search trace ID.
+  google.protobuf.Timestamp start_time = 2;
+  // Optional. The end time to search trace ID.
+  google.protobuf.Timestamp end_time = 3;
 }
 
 message ArchiveTraceResponse {

--- a/proto/api_v3/query_service.proto
+++ b/proto/api_v3/query_service.proto
@@ -27,10 +27,10 @@ option java_package = "io.jaegertracing.api_v3";
 message GetTraceRequest {
   // Hex encoded 64 or 128 bit trace ID.
   string trace_id = 1;
-  // Optional. The start time to search trace id
-  google.protobuf.Timestamp start = 2;
-  // Optional. The end time to search trace id
-  google.protobuf.Timestamp end = 3;
+  // Optional. The start time to search trace ID.
+  google.protobuf.Timestamp start_time = 2;
+  // Optional. The end time to search trace ID.
+  google.protobuf.Timestamp end_time = 3;
 }
 
 // Response object with spans.

--- a/proto/api_v3/query_service.proto
+++ b/proto/api_v3/query_service.proto
@@ -27,6 +27,10 @@ option java_package = "io.jaegertracing.api_v3";
 message GetTraceRequest {
   // Hex encoded 64 or 128 bit trace ID.
   string trace_id = 1;
+  // Optional. The start time to search trace id
+  optional google.protobuf.Timestamp start = 2;
+  // Optional. The end time to search trace id
+  optional google.protobuf.Timestamp end = 3;
 }
 
 // Response object with spans.

--- a/proto/api_v3/query_service.proto
+++ b/proto/api_v3/query_service.proto
@@ -28,9 +28,9 @@ message GetTraceRequest {
   // Hex encoded 64 or 128 bit trace ID.
   string trace_id = 1;
   // Optional. The start time to search trace id
-  optional google.protobuf.Timestamp start = 2;
+  google.protobuf.Timestamp start = 2;
   // Optional. The end time to search trace id
-  optional google.protobuf.Timestamp end = 3;
+  google.protobuf.Timestamp end = 3;
 }
 
 // Response object with spans.

--- a/swagger/api_v3/query_service.swagger.json
+++ b/swagger/api_v3/query_service.swagger.json
@@ -167,6 +167,22 @@
             "in": "path",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "start_time",
+            "description": "Optional. The start time to search trace ID.",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "end_time",
+            "description": "Optional. The end time to search trace ID.",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
           }
         ],
         "tags": [


### PR DESCRIPTION
## Which problem is this PR solving?
- https://github.com/jaegertracing/jaeger/issues/4150

## Short description of the changes
- allow optional time parameters when querying trace by id
