### PR TITLE
Add Go type mapping for new timestamp fields from #95

### DIFF
--- a/proto/api_v2/query.proto
+++ b/proto/api_v2/query.proto
@@ -42,11 +42,11 @@ message GetTraceRequest {
   ];
   // Optional. The start time to search trace ID.
   google.protobuf.Timestamp start_time = 2 [
-    (gogoproto.stdtime) = true,
+    (gogoproto.stdtime) = true
   ];
   // Optional. The end time to search trace ID.
   google.protobuf.Timestamp end_time = 3 [
-    (gogoproto.stdtime) = true,
+    (gogoproto.stdtime) = true
   ];
 }
 
@@ -64,11 +64,11 @@ message ArchiveTraceRequest {
   ];
   // Optional. The start time to search trace ID.
   google.protobuf.Timestamp start_time = 2 [
-    (gogoproto.stdtime) = true,
+    (gogoproto.stdtime) = true
   ];
   // Optional. The end time to search trace ID.
   google.protobuf.Timestamp end_time = 3 [
-    (gogoproto.stdtime) = true,
+    (gogoproto.stdtime) = true
   ];
 }
 

--- a/proto/api_v2/query.proto
+++ b/proto/api_v2/query.proto
@@ -41,9 +41,13 @@ message GetTraceRequest {
     (gogoproto.customname) = "TraceID"
   ];
   // Optional. The start time to search trace ID.
-  google.protobuf.Timestamp start_time = 2;
+  google.protobuf.Timestamp start_time = 2 [
+    (gogoproto.stdtime) = true,
+  ];
   // Optional. The end time to search trace ID.
-  google.protobuf.Timestamp end_time = 3;
+  google.protobuf.Timestamp end_time = 3 [
+    (gogoproto.stdtime) = true,
+  ];
 }
 
 message SpansResponseChunk {
@@ -59,9 +63,13 @@ message ArchiveTraceRequest {
     (gogoproto.customname) = "TraceID"
   ];
   // Optional. The start time to search trace ID.
-  google.protobuf.Timestamp start_time = 2;
+  google.protobuf.Timestamp start_time = 2 [
+    (gogoproto.stdtime) = true,
+  ];
   // Optional. The end time to search trace ID.
-  google.protobuf.Timestamp end_time = 3;
+  google.protobuf.Timestamp end_time = 3 [
+    (gogoproto.stdtime) = true,
+  ];
 }
 
 message ArchiveTraceResponse {

--- a/proto/api_v3/query_service.proto
+++ b/proto/api_v3/query_service.proto
@@ -28,9 +28,13 @@ message GetTraceRequest {
   // Hex encoded 64 or 128 bit trace ID.
   string trace_id = 1;
   // Optional. The start time to search trace ID.
-  google.protobuf.Timestamp start_time = 2;
+  google.protobuf.Timestamp start_time = 2 [
+    (gogoproto.stdtime) = true,
+  ];
   // Optional. The end time to search trace ID.
-  google.protobuf.Timestamp end_time = 3;
+  google.protobuf.Timestamp end_time = 3 [
+    (gogoproto.stdtime) = true,
+  ];
 }
 
 // Response object with spans.

--- a/proto/api_v3/query_service.proto
+++ b/proto/api_v3/query_service.proto
@@ -17,6 +17,7 @@ syntax="proto3";
 package jaeger.api_v3;
 
 import "opentelemetry/proto/trace/v1/trace.proto";
+import "gogoproto/gogo.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/duration.proto";
 

--- a/proto/api_v3/query_service.proto
+++ b/proto/api_v3/query_service.proto
@@ -29,11 +29,11 @@ message GetTraceRequest {
   string trace_id = 1;
   // Optional. The start time to search trace ID.
   google.protobuf.Timestamp start_time = 2 [
-    (gogoproto.stdtime) = true,
+    (gogoproto.stdtime) = true
   ];
   // Optional. The end time to search trace ID.
   google.protobuf.Timestamp end_time = 3 [
-    (gogoproto.stdtime) = true,
+    (gogoproto.stdtime) = true
   ];
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
- The new timestamp fields added in #95 did not have the gogo mappings to use stdlib's time.Time 

## Description of the changes
- add gogo annotations

## How was this change tested?
- CI
