### PR TITLE
Generate pyi for python binding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ PROTOC_WITHOUT_GRPC := $(PROTOC) \
 		--gogo_out=plugins=grpc,$(PROTO_GOGO_MAPPINGS):$(PWD)/${PROTO_GEN_GO_DIR} \
 		--java_out=${PROTO_GEN_JAVA_DIR} \
 		--python_out=${PROTO_GEN_PYTHON_DIR} \
+		--pyi_out=${PROTO_GEN_PYTHON_DIR} \
 		--js_out=${PROTO_GEN_JS_DIR} \
 		--cpp_out=${PROTO_GEN_CPP_DIR} \
 		--csharp_out=base_namespace:${PROTO_GEN_CSHARP_DIR}


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #100 

## Description of the changes
- Generate pyi for python binding

## How was this change tested?
- Tested by my docker-protobuf image: https://github.com/Wh1isper/docker-protobuf
- The `js` part needs to be removed for testing, I didn't dig deep enough to find out why missing `protoc-gen-js`
- docker image `wh1isper/jaeger-protobuf:latest` build on github action: https://github.com/Wh1isper/docker-protobuf/actions/runs/6812647602/job/18525460077

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
