### PR TITLE
[api_v2] Change time fields in ArchiveTraceRequest to non-nullable for gogo

### DIFF
--- a/proto/api_v2/query.proto
+++ b/proto/api_v2/query.proto
@@ -66,11 +66,13 @@ message ArchiveTraceRequest {
   ];
   // Optional. The start time to search trace ID.
   google.protobuf.Timestamp start_time = 2 [
-    (gogoproto.stdtime) = true
+    (gogoproto.stdtime) = true,
+    (gogoproto.nullable) = false
   ];
   // Optional. The end time to search trace ID.
   google.protobuf.Timestamp end_time = 3 [
-    (gogoproto.stdtime) = true
+    (gogoproto.stdtime) = true,
+    (gogoproto.nullable) = false
   ];
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
Part of https://github.com/jaegertracing/jaeger/issues/4150

## Description of the changes
- Make sure type of time fields are aligned with other requests

## How was this change tested?
- unit test

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
