### PR TITLE
add models for dependencies.go, hash.go, keyvalue.go, process.go

### DIFF
--- a/model/v1/dependencies.go
+++ b/model/v1/dependencies.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package model
+
+const (
+	// JaegerDependencyLinkSource describes a dependency diagram that was generated from Jaeger traces.
+	JaegerDependencyLinkSource = "jaeger"
+)
+
+// ApplyDefaults applies defaults to the DependencyLink.
+func (d DependencyLink) ApplyDefaults() DependencyLink {
+	dd := d
+	if dd.Source == "" {
+		dd.Source = JaegerDependencyLinkSource
+	}
+	return dd
+}

--- a/model/v1/dependencies_test.go
+++ b/model/v1/dependencies_test.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2019 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDependencyLinkApplyDefaults(t *testing.T) {
+	dl := DependencyLink{}.ApplyDefaults()
+	assert.Equal(t, JaegerDependencyLinkSource, dl.Source)
+
+	networkSource := "network"
+	dl = DependencyLink{Source: networkSource}.ApplyDefaults()
+	assert.Equal(t, networkSource, dl.Source)
+}

--- a/model/v1/hash.go
+++ b/model/v1/hash.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package model
+
+import (
+	"hash/fnv"
+	"io"
+)
+
+// Hashable interface is for type that can participate in a hash computation
+// by writing their data into io.Writer, which is usually an instance of hash.Hash.
+type Hashable interface {
+	Hash(w io.Writer) error
+}
+
+// HashCode calculates a FNV-1a hash code for a Hashable object.
+func HashCode(o Hashable) (uint64, error) {
+	h := fnv.New64a()
+	if err := o.Hash(h); err != nil {
+		return 0, err
+	}
+	return h.Sum64(), nil
+}

--- a/model/v1/hash_test.go
+++ b/model/v1/hash_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package model_test
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockHashWwiterAnswer struct {
+	n   int
+	err error
+}
+
+type mockHashWwiter struct {
+	answers []mockHashWwiterAnswer
+}
+
+func (w *mockHashWwiter) Write(data []byte) (int, error) {
+	if len(w.answers) == 0 {
+		return 0, fmt.Errorf("no answer registered for call with data=%+v", data)
+	}
+	answer := w.answers[0]
+	w.answers = w.answers[1:]
+	return answer.n, answer.err
+}
+
+type errHashable struct {
+	err error
+}
+
+func (e *errHashable) Hash(io.Writer) error {
+	return e.err
+}
+
+func TestHasCodeError(t *testing.T) {
+	someErr := errors.New("some error")
+	h := &errHashable{err: someErr}
+	n, err := model.HashCode(h)
+	assert.Equal(t, uint64(0), n)
+	assert.Equal(t, someErr, err)
+}

--- a/model/v1/ids.go
+++ b/model/v1/ids.go
@@ -124,10 +124,7 @@ func marshalBytes(dst []byte, src []byte) (n int, err error) {
 // Example: {high:2, low:1} => "AAAAAAAAAAIAAAAAAAAAAQ==".
 func (t TraceID) MarshalJSON() ([]byte, error) {
 	var b [16]byte
-	_, err := t.MarshalTo(b[:]) // can only error on incorrect buffer size
-	if err != nil {
-		return nil, err
-	}
+	t.MarshalTo(b[:]) // can only error on incorrect buffer size
 	s := make([]byte, 24+2)
 	base64.StdEncoding.Encode(s[1:25], b[:])
 	s[0], s[25] = '"', '"'
@@ -213,10 +210,7 @@ func (s *SpanID) Unmarshal(data []byte) error {
 // Example: {1} => "AAAAAAAAAAE=".
 func (s SpanID) MarshalJSON() ([]byte, error) {
 	var b [8]byte
-	_, err := s.MarshalTo(b[:]) // can only error on incorrect buffer size
-	if err != nil {
-		return nil, err
-	}
+	s.MarshalTo(b[:]) // can only error on incorrect buffer size
 	v := make([]byte, 12+2)
 	base64.StdEncoding.Encode(v[1:13], b[:])
 	v[0], v[13] = '"', '"'

--- a/model/v1/ids.go
+++ b/model/v1/ids.go
@@ -124,7 +124,10 @@ func marshalBytes(dst []byte, src []byte) (n int, err error) {
 // Example: {high:2, low:1} => "AAAAAAAAAAIAAAAAAAAAAQ==".
 func (t TraceID) MarshalJSON() ([]byte, error) {
 	var b [16]byte
-	t.MarshalTo(b[:]) // can only error on incorrect buffer size
+	_, err := t.MarshalTo(b[:]) // can only error on incorrect buffer size
+	if err != nil {
+		return nil, err
+	}
 	s := make([]byte, 24+2)
 	base64.StdEncoding.Encode(s[1:25], b[:])
 	s[0], s[25] = '"', '"'
@@ -210,7 +213,10 @@ func (s *SpanID) Unmarshal(data []byte) error {
 // Example: {1} => "AAAAAAAAAAE=".
 func (s SpanID) MarshalJSON() ([]byte, error) {
 	var b [8]byte
-	s.MarshalTo(b[:]) // can only error on incorrect buffer size
+	_, err := s.MarshalTo(b[:]) // can only error on incorrect buffer size
+	if err != nil {
+		return nil, err
+	}
 	v := make([]byte, 12+2)
 	base64.StdEncoding.Encode(v[1:13], b[:])
 	v[0], v[13] = '"', '"'

--- a/model/v1/keyvalue.go
+++ b/model/v1/keyvalue.go
@@ -1,0 +1,246 @@
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package model
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+)
+
+// These constants are kept mostly for backwards compatibility.
+const (
+	// StringType indicates the value is a unicode string
+	StringType = ValueType_STRING
+	// BoolType indicates the value is a Boolean encoded as int64 number 0 or 1
+	BoolType = ValueType_BOOL
+	// Int64Type indicates the value is an int64 number
+	Int64Type = ValueType_INT64
+	// Float64Type indicates the value is a float64 number stored as int64
+	Float64Type = ValueType_FLOAT64
+	// BinaryType indicates the value is binary blob stored as a byte array
+	BinaryType = ValueType_BINARY
+
+	SpanKindKey     = "span.kind"
+	SamplerTypeKey  = "sampler.type"
+	SamplerParamKey = "sampler.param"
+)
+
+type SpanKind string
+
+const (
+	SpanKindClient      SpanKind = "client"
+	SpanKindServer      SpanKind = "server"
+	SpanKindProducer    SpanKind = "producer"
+	SpanKindConsumer    SpanKind = "consumer"
+	SpanKindInternal    SpanKind = "internal"
+	SpanKindUnspecified SpanKind = ""
+)
+
+func SpanKindFromString(kind string) (SpanKind, error) {
+	switch SpanKind(kind) {
+	case SpanKindClient, SpanKindServer, SpanKindProducer, SpanKindConsumer, SpanKindInternal, SpanKindUnspecified:
+		return SpanKind(kind), nil
+	default:
+		return SpanKindUnspecified, fmt.Errorf("unknown span kind %q", kind)
+	}
+}
+
+// KeyValues is a type alias that exposes convenience functions like Sort, FindByKey.
+type KeyValues []KeyValue
+
+// String creates a String-typed KeyValue
+func String(key string, value string) KeyValue {
+	return KeyValue{Key: key, VType: StringType, VStr: value}
+}
+
+// Bool creates a Bool-typed KeyValue
+func Bool(key string, value bool) KeyValue {
+	return KeyValue{Key: key, VType: BoolType, VBool: value}
+}
+
+// Int64 creates a Int64-typed KeyValue
+func Int64(key string, value int64) KeyValue {
+	return KeyValue{Key: key, VType: Int64Type, VInt64: value}
+}
+
+// Float64 creates a Float64-typed KeyValue
+func Float64(key string, value float64) KeyValue {
+	return KeyValue{Key: key, VType: Float64Type, VFloat64: value}
+}
+
+// Binary creates a Binary-typed KeyValue
+func Binary(key string, value []byte) KeyValue {
+	return KeyValue{Key: key, VType: BinaryType, VBinary: value}
+}
+
+// Bool returns the Boolean value stored in this KeyValue or false if it stores a different type.
+// The caller must check VType before using this method.
+func (kv *KeyValue) Bool() bool {
+	if kv.VType == BoolType {
+		return kv.VBool
+	}
+	return false
+}
+
+// Int64 returns the Int64 value stored in this KeyValue or 0 if it stores a different type.
+// The caller must check VType before using this method.
+func (kv *KeyValue) Int64() int64 {
+	if kv.VType == Int64Type {
+		return kv.VInt64
+	}
+	return 0
+}
+
+// Float64 returns the Float64 value stored in this KeyValue or 0 if it stores a different type.
+// The caller must check VType before using this method.
+func (kv *KeyValue) Float64() float64 {
+	if kv.VType == Float64Type {
+		return kv.VFloat64
+	}
+	return 0
+}
+
+// Binary returns the blob ([]byte) value stored in this KeyValue or nil if it stores a different type.
+// The caller must check VType before using this method.
+func (kv *KeyValue) Binary() []byte {
+	if kv.VType == BinaryType {
+		return kv.VBinary
+	}
+	return nil
+}
+
+// Value returns typed values stored in KeyValue as any.
+func (kv *KeyValue) Value() any {
+	switch kv.VType {
+	case StringType:
+		return kv.VStr
+	case BoolType:
+		return kv.VBool
+	case Int64Type:
+		return kv.VInt64
+	case Float64Type:
+		return kv.VFloat64
+	case BinaryType:
+		return kv.VBinary
+	default:
+		return fmt.Errorf("unknown type %d", kv.VType)
+	}
+}
+
+// AsStringLossy returns a potentially lossy string representation of the value.
+func (kv *KeyValue) AsStringLossy() string {
+	return kv.asString(true)
+}
+
+// AsString returns a string representation of the value.
+func (kv *KeyValue) AsString() string {
+	return kv.asString(false)
+}
+
+func (kv *KeyValue) asString(truncate bool) string {
+	switch kv.VType {
+	case StringType:
+		return kv.VStr
+	case BoolType:
+		if kv.Bool() {
+			return "true"
+		}
+		return "false"
+	case Int64Type:
+		return strconv.FormatInt(kv.Int64(), 10)
+	case Float64Type:
+		return strconv.FormatFloat(kv.Float64(), 'g', 10, 64)
+	case BinaryType:
+		if truncate && len(kv.VBinary) > 256 {
+			return hex.EncodeToString(kv.VBinary[0:256]) + "..."
+		}
+		return hex.EncodeToString(kv.VBinary)
+	default:
+		return fmt.Sprintf("unknown type %d", kv.VType)
+	}
+}
+
+// IsLess compares KeyValue object with another KeyValue.
+// The order is based first on the keys, then on type, and finally on the value.
+func (kv *KeyValue) IsLess(two *KeyValue) bool {
+	return kv.Compare(two) < 0
+}
+
+func (kvs KeyValues) Len() int      { return len(kvs) }
+func (kvs KeyValues) Swap(i, j int) { kvs[i], kvs[j] = kvs[j], kvs[i] }
+func (kvs KeyValues) Less(i, j int) bool {
+	return kvs[i].IsLess(&kvs[j])
+}
+
+// Sort does in-place sorting of KeyValues, then by value type, then by value.
+func (kvs KeyValues) Sort() {
+	sort.Sort(kvs)
+}
+
+// FindByKey scans the list of key-values searching for the first one with the given key.
+// Returns found tag and a boolean flag indicating if the search was successful.
+func (kvs KeyValues) FindByKey(key string) (KeyValue, bool) {
+	for _, kv := range kvs {
+		if kv.Key == key {
+			return kv, true
+		}
+	}
+	return KeyValue{}, false
+}
+
+// Equal compares KeyValues with another list. Both lists must be already sorted.
+func (kvs KeyValues) Equal(other KeyValues) bool {
+	l1, l2 := len(kvs), len(other)
+	if l1 != l2 {
+		return false
+	}
+	for i := 0; i < l1; i++ {
+		if !kvs[i].Equal(&other[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// Hash implements Hash from Hashable.
+func (kvs KeyValues) Hash(w io.Writer) error {
+	for i := range kvs {
+		if err := kvs[i].Hash(w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Hash implements Hash from Hashable.
+func (kv KeyValue) Hash(w io.Writer) error {
+	if _, err := w.Write([]byte(kv.Key)); err != nil {
+		return err
+	}
+	//nolint: gosec // G115
+	if err := binary.Write(w, binary.BigEndian, uint16(kv.VType)); err != nil {
+		return err
+	}
+	var err error
+	switch kv.VType {
+	case StringType:
+		_, err = w.Write([]byte(kv.VStr))
+	case BoolType:
+		err = binary.Write(w, binary.BigEndian, kv.VBool)
+	case Int64Type:
+		err = binary.Write(w, binary.BigEndian, kv.VInt64)
+	case Float64Type:
+		err = binary.Write(w, binary.BigEndian, kv.VFloat64)
+	case BinaryType:
+		_, err = w.Write(kv.VBinary)
+	default:
+		err = fmt.Errorf("unknown type %d", kv.VType)
+	}
+	return err
+}

--- a/model/v1/keyvalue_test.go
+++ b/model/v1/keyvalue_test.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package model_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyValueString(t *testing.T) {
+	kv := model.String("x", "y")
+	assert.Equal(t, "x", kv.Key)
+	assert.Equal(t, model.StringType, kv.VType)
+	assert.Equal(t, "y", kv.VStr)
+	assert.False(t, kv.Bool())
+	assert.Equal(t, int64(0), kv.Int64())
+	assert.InDelta(t, float64(0), kv.Float64(), 0.01)
+	assert.Nil(t, kv.Binary())
+}
+
+func TestKeyValueBool(t *testing.T) {
+	kv := model.Bool("x", true)
+	assert.Equal(t, "x", kv.Key)
+	assert.Equal(t, model.BoolType, kv.VType)
+	assert.True(t, kv.Bool())
+}
+
+func TestKeyValueInt64(t *testing.T) {
+	kv := model.Int64("x", 123)
+	assert.Equal(t, "x", kv.Key)
+	assert.Equal(t, model.Int64Type, kv.VType)
+	assert.Equal(t, int64(123), kv.Int64())
+}
+
+func TestKeyValueFloat64(t *testing.T) {
+	kv := model.Float64("x", 123.345)
+	assert.Equal(t, "x", kv.Key)
+	assert.Equal(t, model.Float64Type, kv.VType)
+	assert.InDelta(t, 123.345, kv.Float64(), 1e-4)
+}
+
+func TestKeyValueBinary(t *testing.T) {
+	kv := model.Binary("x", []byte{123, 45})
+	assert.Equal(t, "x", kv.Key)
+	assert.Equal(t, model.BinaryType, kv.VType)
+	assert.Equal(t, []byte{123, 45}, kv.Binary())
+}
+
+func TestKeyValueIsLessAndEqual(t *testing.T) {
+	testCases := []struct {
+		name  string
+		kv1   model.KeyValue
+		kv2   model.KeyValue
+		equal bool
+	}{
+		{name: "different keys", kv1: model.String("x", "123"), kv2: model.String("y", "123")},
+		{name: "same key different types", kv1: model.String("x", "123"), kv2: model.Int64("x", 123)},
+		{name: "different string values", kv1: model.String("x", "123"), kv2: model.String("x", "567")},
+		{name: "different bool values", kv1: model.Bool("x", false), kv2: model.Bool("x", true)},
+		{name: "different int64 values", kv1: model.Int64("x", 123), kv2: model.Int64("x", 567)},
+		{name: "different float64 values", kv1: model.Float64("x", 123), kv2: model.Float64("x", 567)},
+		{name: "different blob length", kv1: model.Binary("x", []byte{1, 2}), kv2: model.Binary("x", []byte{1, 2, 3})},
+		{name: "different blob values", kv1: model.Binary("x", []byte{1, 2, 3}), kv2: model.Binary("x", []byte{1, 2, 4})},
+		{name: "empty blob", kv1: model.Binary("x", nil), kv2: model.Binary("x", nil), equal: true},
+		{name: "identical blob", kv1: model.Binary("x", []byte{1, 2, 3}), kv2: model.Binary("x", []byte{1, 2, 3}), equal: true},
+	}
+	for _, tt := range testCases {
+		testCase := tt // capture loop var
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.equal {
+				assert.False(t, testCase.kv1.IsLess(&testCase.kv2))
+				assert.True(t, testCase.kv1.Equal(&testCase.kv2))
+				assert.True(t, testCase.kv2.Equal(&testCase.kv1))
+			} else {
+				assert.True(t, testCase.kv1.IsLess(&testCase.kv2))
+				assert.False(t, testCase.kv1.Equal(&testCase.kv2))
+				assert.False(t, testCase.kv2.Equal(&testCase.kv1))
+			}
+			assert.False(t, testCase.kv2.IsLess(&testCase.kv1))
+		})
+	}
+	t.Run("invalid type", func(t *testing.T) {
+		v1 := model.KeyValue{Key: "x", VType: model.ValueType(-1)}
+		v2 := model.KeyValue{Key: "x", VType: model.ValueType(-2)}
+		assert.False(t, v1.IsLess(&v2))
+		assert.True(t, v2.IsLess(&v1))
+		assert.False(t, v1.Equal(&v2))
+		assert.False(t, v2.Equal(&v1))
+	})
+}
+
+func TestKeyValueAsStringAndValue(t *testing.T) {
+	longString := `Bender Bending Rodrigues Bender Bending Rodrigues Bender Bending Rodrigues Bender Bending Rodrigues
+	Bender Bending Rodrigues Bender Bending Rodrigues Bender Bending Rodrigues Bender Bending Rodrigues Bender Bending Rodrigues
+	Bender Bending Rodrigues Bender Bending Rodrigues Bender Bending Rodrigues Bender Bending Rodrigues Bender Bending Rodrigues
+	Bender Bending Rodrigues Bender Bending Rodrigues Bender Bending Rodrigues Bender Bending Rodrigues Bender Bending Rodrigues
+	Bender Bending Rodrigues Bender Bending Rodrigues Bender Bending Rodrigues Bender Bending Rodrigues Bender Bending Rodrigues `
+	expectedBinaryStr := `42656e6465722042656e64696e6720526f647269677565732042656e6465722042656e64696e6720526f647269677565732042656e6465722042656e64696e6720526f647269677565732042656e6465722042656e64696e6720526f647269677565730a0942656e6465722042656e64696e6720526f647269677565732042656e6465722042656e64696e6720526f647269677565732042656e6465722042656e64696e6720526f647269677565732042656e6465722042656e64696e6720526f647269677565732042656e6465722042656e64696e6720526f647269677565730a0942656e6465722042656e64696e6720526f647269677565732042656e6465722042656e64696e6720526f647269677565732042656e6465722042656e64696e6720526f647269677565732042656e6465722042656e64696e6720526f647269677565732042656e6465722042656e64696e6720526f647269677565730a0942656e6465722042656e64696e6720526f647269677565732042656e6465722042656e64696e6720526f647269677565732042656e6465722042656e64696e6720526f647269677565732042656e6465722042656e64696e6720526f647269677565732042656e6465722042656e64696e6720526f647269677565730a0942656e6465722042656e64696e6720526f647269677565732042656e6465722042656e64696e6720526f647269677565732042656e6465722042656e64696e6720526f647269677565732042656e6465722042656e64696e6720526f647269677565732042656e6465722042656e64696e6720526f6472696775657320`
+	expectedBinaryStrLossy := `42656e6465722042656e64696e6720526f647269677565732042656e6465722042656e64696e6720526f647269677565732042656e6465722042656e64696e6720526f647269677565732042656e6465722042656e64696e6720526f647269677565730a0942656e6465722042656e64696e6720526f647269677565732042656e6465722042656e64696e6720526f647269677565732042656e6465722042656e64696e6720526f647269677565732042656e6465722042656e64696e6720526f647269677565732042656e6465722042656e64696e6720526f647269677565730a0942656e6465722042656e64696e6720526f647269677565732042656e64...`
+	testCases := []struct {
+		name     string
+		kv       model.KeyValue
+		str      string
+		strLossy string
+		val      any
+	}{
+		{name: "Bender is great!", kv: model.String("x", "Bender is great!"), str: "Bender is great!", val: "Bender is great!"},
+		{name: "false", kv: model.Bool("x", false), str: "false", val: false},
+		{name: "true", kv: model.Bool("x", true), str: "true", val: true},
+		{name: "3000", kv: model.Int64("x", 3000), str: "3000", val: int64(3000)},
+		{name: "-1947", kv: model.Int64("x", -1947), str: "-1947", val: int64(-1947)},
+		{name: "3.141592654", kv: model.Float64("x", 3.14159265359), str: "3.141592654", val: float64(3.14159265359)},
+		{name: "42656e646572", kv: model.Binary("x", []byte("Bender")), str: "42656e646572", val: []byte("Bender")},
+		{name: "binary string", kv: model.Binary("x", []byte(longString)), str: expectedBinaryStr, val: []byte(longString)},
+		{name: "binary string (lossy)", kv: model.Binary("x", []byte(longString)), strLossy: expectedBinaryStrLossy, val: []byte(longString)},
+	}
+	for _, tt := range testCases {
+		testCase := tt // capture loop var
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.strLossy != "" {
+				assert.Equal(t, testCase.strLossy, testCase.kv.AsStringLossy())
+			} else {
+				assert.Equal(t, testCase.str, testCase.kv.AsString())
+			}
+			assert.Equal(t, testCase.val, testCase.kv.Value())
+		})
+	}
+	t.Run("invalid type", func(t *testing.T) {
+		kv := model.KeyValue{Key: "x", VType: model.ValueType(-1)}
+		assert.Equal(t, "unknown type -1", kv.AsString())
+		require.EqualError(t, kv.Value().(error), "unknown type -1")
+	})
+}
+
+func TestKeyValueHash(t *testing.T) {
+	testCases := []struct {
+		kv model.KeyValue
+	}{
+		{kv: model.String("x", "Bender is great!")},
+		{kv: model.Bool("x", true)},
+		{kv: model.Int64("x", 3000)},
+		{kv: model.Float64("x", 3.14159265359)},
+		{kv: model.Binary("x", []byte("Bender"))},
+	}
+	for _, tt := range testCases {
+		testCase := tt // capture loop var
+		t.Run(testCase.kv.String(), func(t *testing.T) {
+			out := new(bytes.Buffer)
+			require.NoError(t, testCase.kv.Hash(out))
+		})
+	}
+}

--- a/model/v1/keyvalues_test.go
+++ b/model/v1/keyvalues_test.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package model_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyValuesSort(t *testing.T) {
+	input := model.KeyValues{
+		model.String("x", "z"),
+		model.String("x", "y"),
+		model.Int64("a", 2),
+		model.Int64("a", 1),
+		model.Float64("x", 2),
+		model.Float64("x", 1),
+		model.Bool("x", true),
+		model.Bool("x", false),
+	}
+	expected := model.KeyValues{
+		model.Int64("a", 1),
+		model.Int64("a", 2),
+		model.String("x", "y"),
+		model.String("x", "z"),
+		model.Bool("x", false),
+		model.Bool("x", true),
+		model.Float64("x", 1),
+		model.Float64("x", 2),
+	}
+	input.Sort()
+	assert.Equal(t, expected, input)
+}
+
+func TestSpanKindFromString(t *testing.T) {
+	testCases := []struct {
+		input  string
+		output model.SpanKind
+		err    string
+	}{
+		{input: "client", output: model.SpanKindClient},
+		{input: "", output: model.SpanKindUnspecified},
+		{input: "foobar", output: model.SpanKindUnspecified, err: "unknown span kind"},
+	}
+	for _, test := range testCases {
+		t.Run(fmt.Sprintf("%+v", test), func(t *testing.T) {
+			v, err := model.SpanKindFromString(test.input)
+			if test.err != "" {
+				require.ErrorContains(t, err, test.err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, test.output, v)
+		})
+	}
+}
+
+func TestKeyValuesFindByKey(t *testing.T) {
+	input := model.KeyValues{
+		model.String("x", "z"),
+		model.String("x", "y"),
+		model.Int64("a", 2),
+	}
+
+	testCases := []struct {
+		key   string
+		found bool
+		kv    model.KeyValue
+	}{
+		{"b", false, model.KeyValue{}},
+		{"a", true, model.Int64("a", 2)},
+		{"x", true, model.String("x", "z")},
+	}
+
+	for _, test := range testCases {
+		t.Run(fmt.Sprintf("%+v", test), func(t *testing.T) {
+			kv, found := input.FindByKey(test.key)
+			assert.Equal(t, test.found, found)
+			assert.Equal(t, test.kv, kv)
+		})
+	}
+}
+
+func TestKeyValuesEqual(t *testing.T) {
+	v1 := model.String("s", "abc")
+	v2 := model.Int64("i", 123)
+	v3 := model.Float64("f", 123.4)
+	assert.True(t, model.KeyValues{}.Equal(model.KeyValues{}))
+	assert.True(t, model.KeyValues{v1}.Equal(model.KeyValues{v1}))
+	assert.True(t, model.KeyValues{v1, v2}.Equal(model.KeyValues{v1, v2}))
+	assert.False(t, model.KeyValues{v1, v2}.Equal(model.KeyValues{v2, v1}))
+	assert.False(t, model.KeyValues{v1, v2}.Equal(model.KeyValues{v1, v3}))
+	assert.False(t, model.KeyValues{v1, v2}.Equal(model.KeyValues{v1, v2, v3}))
+}
+
+func TestKeyValuesHashErrors(t *testing.T) {
+	kvs := model.KeyValues{
+		model.String("x", "y"),
+	}
+	someErr := errors.New("some error")
+	for i := 0; i < 3; i++ {
+		// mock writer with i-1 successful answers, and one failed answer
+		w := &mockHashWwiter{
+			answers: make([]mockHashWwiterAnswer, i+1),
+		}
+		w.answers[i] = mockHashWwiterAnswer{1, someErr}
+		assert.Equal(t, someErr, kvs.Hash(w))
+	}
+	kvs[0].VType = model.ValueType(-1)
+	w := &mockHashWwiter{
+		answers: make([]mockHashWwiterAnswer, 3),
+	}
+	require.EqualError(t, kvs.Hash(w), "unknown type -1")
+}
+
+// No memory allocations for IsLess and Equal
+// 18.6 ns/op	       0 B/op	       0 allocs/op
+func BenchmarkKeyValueIsLessAndEquals(b *testing.B) {
+	v1 := model.KeyValue{Key: "x", VType: model.ValueType(-1)}
+	v2 := model.KeyValue{Key: "x", VType: model.ValueType(-1)}
+	for i := 0; i < b.N; i++ {
+		v1.IsLess(&v2)
+		v2.IsLess(&v1)
+		v1.Equal(&v2)
+		v2.Equal(&v1)
+	}
+}
+
+// No memory allocations for Sort (1 alloc comes from the algorithm, not from comparisons)
+// 107 ns/op	      32 B/op	       1 allocs/op
+func BenchmarkKeyValuesSort(b *testing.B) {
+	v1 := model.KeyValue{Key: "x", VType: model.ValueType(-1)}
+	v2 := model.KeyValue{Key: "x", VType: model.ValueType(-1)}
+	list := model.KeyValues(make([]model.KeyValue, 5))
+	for i := 0; i < b.N; i++ {
+		list[0], list[1], list[2], list[3], list[4] = v2, v1, v2, v1, v2
+		list.Sort()
+	}
+}
+
+// No memory allocations from wrapping sliceinto model.KeyValues()
+// 0.53 ns/op	       0 B/op	       0 allocs/op
+func BenchmarkKeyValuesWrapping(b *testing.B) {
+	kv := []model.KeyValue{
+		model.String("x", "y"),
+		model.Int64("n", 42),
+	}
+	for i := 0; i < b.N; i++ {
+		model.KeyValues(kv).Len()
+	}
+}

--- a/model/v1/process.go
+++ b/model/v1/process.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package model
+
+import (
+	"io"
+)
+
+// NewProcess creates a new Process for given serviceName and tags.
+// The tags are sorted in place and kept in the same array/slice,
+// in order to store the Process in a canonical form that is relied
+// upon by the Equal and Hash functions.
+func NewProcess(serviceName string, tags []KeyValue) *Process {
+	typedTags := KeyValues(tags)
+	typedTags.Sort()
+	return &Process{ServiceName: serviceName, Tags: typedTags}
+}
+
+// Equal compares Process object with another Process.
+func (p *Process) Equal(other *Process) bool {
+	if p.ServiceName != other.ServiceName {
+		return false
+	}
+	return KeyValues(p.Tags).Equal(other.Tags)
+}
+
+// Hash implements Hash from Hashable.
+func (p *Process) Hash(w io.Writer) (err error) {
+	if _, err := w.Write([]byte(p.ServiceName)); err != nil {
+		return err
+	}
+	return KeyValues(p.Tags).Hash(w)
+}

--- a/model/v1/process_test.go
+++ b/model/v1/process_test.go
@@ -44,13 +44,15 @@ func TestProcessEqual(t *testing.T) {
 	assert.False(t, p1.Equal(p5))
 }
 
-func Hash(w io.Writer) {
-	w.Write([]byte("hello"))
+func Hash(w io.Writer) error {
+	_, err := w.Write([]byte("hello"))
+	return err
 }
 
-func TestX(*testing.T) {
+func TestX(t *testing.T) {
 	h := fnv.New64a()
-	Hash(h)
+	err := Hash(h)
+	require.NoError(t, err)
 }
 
 func TestProcessHash(t *testing.T) {

--- a/model/v1/process_test.go
+++ b/model/v1/process_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package model_test
+
+import (
+	"errors"
+	"hash/fnv"
+	"io"
+	"testing"
+
+	"github.com/jaegertracing/jaeger-idl/model/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessEqual(t *testing.T) {
+	p1 := model.NewProcess("s1", []model.KeyValue{
+		model.String("x", "y"),
+		model.Int64("a", 1),
+	})
+	p2 := model.NewProcess("s1", []model.KeyValue{
+		model.Int64("a", 1),
+		model.String("x", "y"),
+	})
+	p3 := model.NewProcess("S2", []model.KeyValue{
+		model.Int64("a", 1),
+		model.String("x", "y"),
+	})
+	p4 := model.NewProcess("s1", []model.KeyValue{
+		model.Int64("a", 1),
+		model.Float64("a", 1.1),
+		model.String("x", "y"),
+	})
+	p5 := model.NewProcess("s1", []model.KeyValue{
+		model.Float64("a", 1.1),
+		model.String("x", "y"),
+	})
+	assert.Equal(t, p1, p2)
+	assert.True(t, p1.Equal(p2))
+	assert.False(t, p1.Equal(p3))
+	assert.False(t, p1.Equal(p4))
+	assert.False(t, p1.Equal(p5))
+}
+
+func Hash(w io.Writer) {
+	w.Write([]byte("hello"))
+}
+
+func TestX(*testing.T) {
+	h := fnv.New64a()
+	Hash(h)
+}
+
+func TestProcessHash(t *testing.T) {
+	p1 := model.NewProcess("s1", []model.KeyValue{
+		model.String("x", "y"),
+		model.Int64("y", 1),
+		model.Binary("z", []byte{1}),
+	})
+	p1copy := model.NewProcess("s1", []model.KeyValue{
+		model.String("x", "y"),
+		model.Int64("y", 1),
+		model.Binary("z", []byte{1}),
+	})
+	p2 := model.NewProcess("s2", []model.KeyValue{
+		model.String("x", "y"),
+		model.Int64("y", 1),
+		model.Binary("z", []byte{1}),
+	})
+	p1h, err := model.HashCode(p1)
+	require.NoError(t, err)
+	p1ch, err := model.HashCode(p1copy)
+	require.NoError(t, err)
+	p2h, err := model.HashCode(p2)
+	require.NoError(t, err)
+	assert.Equal(t, p1h, p1ch)
+	assert.NotEqual(t, p1h, p2h)
+}
+
+func TestProcessHashError(t *testing.T) {
+	p1 := model.NewProcess("s1", []model.KeyValue{
+		model.String("x", "y"),
+	})
+	someErr := errors.New("some error")
+	w := &mockHashWwiter{
+		answers: []mockHashWwiterAnswer{
+			{1, someErr},
+		},
+	}
+	assert.Equal(t, someErr, p1.Hash(w))
+}


### PR DESCRIPTION
## Which problem is this PR solving?
[#6571](https://github.com/jaegertracing/jaeger/issues/6571)

## Description of the changes
- Copy set of types from original `model/` -> `dependencies.go`, `hash.go`, `keyvalue.go`, `process.go` 

## How was this change tested?
- `go test ./model/v1`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for lint: `golangci-lint run  ./model/v1/`
  - for tests: `go test ./model/v1`
