### PR TITLE
Remove -Imodel/proto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ proto-prepare:
 
 .PHONY: proto-prototest
 proto-prototest:
-	$(PROTOC) -Imodel/proto --go_out=$(PWD)/model/v1/ model/v1/prototest/model_test.proto
+	$(PROTOC) --go_out=$(PWD)/model/v1/ model/v1/prototest/model_test.proto
 
 .PHONY: proto-api-v2
 proto-api-v2:


### PR DESCRIPTION
## Which problem is this PR solving?
when running `make proto` a warning was logged
```
model/proto: warning: directory does not exist.
```

## Description of the changes
- Remove unused import path
