### PR TITLE
[grpc][v2] Move gRPC API from `jaeger` to `jaeger-idl`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ test-ci:
 proto: proto-prepare proto-api-v2 proto-prototest
 
 # proto-all target is used to generate code for all languages as a validation step.
-proto-all: proto-prepare-all proto-api-v2-all proto-api-v3-all
+proto-all: proto-prepare-all proto-api-v2-all proto-api-v3-all proto-storage-all
 
 .PHONY: proto-prepare-all
 proto-prepare-all:
@@ -311,6 +311,17 @@ proto-api-v3-all:
 		google/api/http.proto \
 		protoc-gen-swagger/options/annotations.proto \
 		protoc-gen-swagger/options/openapiv2.proto \
+		gogoproto/gogo.proto
+
+
+.PHONY: proto-storage-all
+proto-storage-all:
+	$(PROTOC_WITH_GRPC) \
+		proto/storage/v2/trace_storage.proto
+	$(PROTOC_WITH_GRPC) \
+		proto/storage/v2/dependency_storage.proto
+
+	$(PROTOC_INTERNAL) \
 		gogoproto/gogo.proto
 
 .PHONY: proto-zipkin

--- a/Makefile
+++ b/Makefile
@@ -321,9 +321,6 @@ proto-storage-all:
 	$(PROTOC_WITH_GRPC) \
 		proto/storage/v2/dependency_storage.proto
 
-	$(PROTOC_INTERNAL) \
-		gogoproto/gogo.proto
-
 .PHONY: proto-zipkin
 proto-zipkin: proto-prepare-all
 	$(PROTOC_WITHOUT_GRPC) \

--- a/proto/storage/v2/dependency_storage.proto
+++ b/proto/storage/v2/dependency_storage.proto
@@ -1,0 +1,39 @@
+syntax = "proto3";
+
+package jaeger.storage.v2;
+
+import "gogoproto/gogo.proto";
+import "google/protobuf/timestamp.proto";
+
+option go_package = "storage";
+
+message GetDependenciesRequest {
+  // start_time is the start of the time interval to search for the dependencies.
+  google.protobuf.Timestamp start_time = 1;
+  // end_time is the end of the time interval to search for the dependencies.
+  google.protobuf.Timestamp end_time = 2;
+}
+
+// Dependency represents a relationship between two services.
+message Dependency {
+  // parent is the name of the caller service.
+  string parent = 1;
+
+  // child is the name of the service being called.
+  string child = 2;
+
+  // call_count is the number of times the parent service called the child service.
+  uint64 call_count = 3;
+
+  // source contains the origin from where the dependency was extracted.
+  string source = 4;
+}
+
+message GetDependenciesResponse {
+  repeated Dependency dependencies = 1;
+}
+
+service DependencyReader {
+  // GetDependencies loads service dependencies from storage.
+  rpc GetDependencies(GetDependenciesRequest) returns (GetDependenciesResponse);
+}

--- a/proto/storage/v2/dependency_storage.proto
+++ b/proto/storage/v2/dependency_storage.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package jaeger.storage.v2;
 
-import "gogoproto/gogo.proto";
 import "google/protobuf/timestamp.proto";
 
 option go_package = "storage";

--- a/proto/storage/v2/trace_storage.proto
+++ b/proto/storage/v2/trace_storage.proto
@@ -1,0 +1,174 @@
+syntax = "proto3";
+
+package jaeger.storage.v2;
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+import "opentelemetry/proto/trace/v1/trace.proto";
+
+option go_package = "storage";
+
+// GetTraceParams represents the query for a single trace from the storage backend.
+message GetTraceParams {
+  // trace_id is a 16 byte array containing the unique identifier for the trace to query.
+  bytes trace_id = 1;
+
+  // start_time is the start of the time interval to search for the trace_id.
+  //
+  // This field is optional.
+  google.protobuf.Timestamp start_time = 2;
+
+  // end_time is the end of the time interval to search for the trace_id.
+  //
+  // This field is optional.
+  google.protobuf.Timestamp end_time = 3;
+}
+
+// GetTracesRequest represents a request to retrieve multiple traces.
+message GetTracesRequest {
+  repeated GetTraceParams query = 1;
+}
+
+// GetServicesRequest represents a request to get service names.
+message GetServicesRequest {}
+
+// GetServicesResponse represents the response for GetServicesRequest.
+message GetServicesResponse {
+  repeated string services = 1;
+}
+
+// GetOperationsRequest represents a request to get operation names.
+message GetOperationsRequest {
+  // service is the name of the service for which to get operation names.
+  //
+  // This field is required.
+  string service = 1;
+
+  // span_kind is the type of span which is used to distinguish between
+  // spans generated in a particular context.
+  //
+  // This field is optional.
+  string span_kind = 2;
+}
+
+// Operation contains information about an operation for a given service.
+message Operation {
+  string name = 1;
+  string span_kind = 2;
+}
+
+// GetOperationsResponse represents the response for GetOperationsRequest.
+message GetOperationsResponse {
+  repeated Operation operations = 1;
+}
+
+// KeyValue and all its associated types are copied from opentelemetry-proto/common/v1/common.proto
+// (https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/common/v1/common.proto).
+// This type is used to store attributes in traces.
+message KeyValue {
+  string key = 1;
+  AnyValue value = 2;
+}
+
+message AnyValue {
+  oneof value {
+    string string_value = 1;
+    bool bool_value = 2;
+    int64 int_value = 3;
+    double double_value = 4;
+    ArrayValue array_value = 5;
+    KeyValueList kvlist_value = 6;
+    bytes bytes_value = 7;
+  }
+}
+
+message KeyValueList {
+  repeated KeyValue values = 1;
+}
+
+message ArrayValue {
+  repeated AnyValue values = 1;
+}
+
+// TraceQueryParameters contains query parameters to find traces. For a detailed
+// definition of each field in this message, refer to `TraceQueryParameters` in `jaeger.api_v3`
+// (https://github.com/jaegertracing/jaeger-idl/blob/main/proto/api_v3/query_service.proto).
+message TraceQueryParameters {
+  string service_name = 1;
+  string operation_name = 2;
+  repeated KeyValue attributes = 3;
+  google.protobuf.Timestamp start_time_min = 4;
+  google.protobuf.Timestamp start_time_max = 5;
+  google.protobuf.Duration duration_min = 6;
+  google.protobuf.Duration duration_max = 7;
+  int32 search_depth = 8;
+}
+
+// FindTracesRequest represents a request to find traces.
+// It can be used to retrieve the traces (FindTraces) or simply
+// the trace IDs (FindTraceIDs).
+message FindTracesRequest {
+  TraceQueryParameters query = 1;
+}
+
+// FoundTraceID is a wrapper around trace ID returned from FindTraceIDs
+// with an optional time range that may be used in GetTraces calls.
+//
+// The time range is provided as an optimization hint for some storage backends
+// that can perform more efficient queries when they know the approximate time range.
+// The value should not be used for precise time-based filtering or assumptions.
+// It is meant as a rough boundary and may not be populated in all cases.
+message FoundTraceID {
+  bytes trace_id = 1;
+  google.protobuf.Timestamp start = 2;
+  google.protobuf.Timestamp end = 3;
+}
+
+// FindTraceIDsResponse represents the response for FindTracesRequest.
+message FindTraceIDsResponse {
+  repeated FoundTraceID trace_ids = 1;
+}
+
+// TraceReader is a service that allows reading traces from storage.
+// Note that if you implement this service, you should also implement
+// OTEL's TraceService in package opentelemetry.proto.collector.trace.v1
+// to allow pushing traces to the storage backend
+// (https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/trace/v1/trace_service.proto)
+service TraceReader {
+  // GetTraces returns a stream that retrieves all traces with given IDs.
+  //
+  // Chunking requirements:
+  // - A single TracesData chunk MUST NOT contain spans from multiple traces.
+  // - Large traces MAY be split across multiple, *consecutive* TracesData chunks.
+  // - Each returned TracesData object MUST NOT be empty.
+  //
+  // Edge cases:
+  // - If no spans are found for any given trace ID, the ID is ignored.
+  // - If none of the trace IDs are found in the storage, an empty response is returned.
+  rpc GetTraces(GetTracesRequest) returns (stream opentelemetry.proto.trace.v1.TracesData) {}
+
+  // GetServices returns all service names known to the backend from traces
+  // within its retention period.
+  rpc GetServices(GetServicesRequest) returns (GetServicesResponse) {}
+
+  // GetOperations returns all operation names for a given service
+  // known to the backend from traces within its retention period.
+  rpc GetOperations(GetOperationsRequest) returns (GetOperationsResponse) {}
+
+  // FindTraces returns a stream that retrieves traces matching query parameters.
+  //
+  // The chunking rules are the same as for GetTraces.
+  //
+  // If no matching traces are found, an empty stream is returned.
+  rpc FindTraces(FindTracesRequest) returns (stream opentelemetry.proto.trace.v1.TracesData) {}
+
+  // FindTraceIDs returns a stream that retrieves IDs of traces matching query parameters.
+  //
+  // If no matching traces are found, an empty stream is returned.
+  //
+  // This call behaves identically to FindTraces, except that it returns only the list
+  // of matching trace IDs. This is useful in some contexts, such as batch jobs, where a
+  // large list of trace IDs may be queried first and then the full traces are loaded
+  // in batches.
+  rpc FindTraceIDs(FindTracesRequest) returns (FindTraceIDsResponse) {}
+}


### PR DESCRIPTION
## Which problem is this PR solving?
- Towards https://github.com/jaegertracing/jaeger/issues/7089

## Description of the changes
- This PR copies the gRPC API definitions from `jaeger` to this repository. In a follow-up PR, the proto definitions will be removed from `jaeger` and will point to this repo instead.

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
