### PR TITLE
/api/v3/traces http doc update

### DIFF
--- a/swagger/api_v3/query_service.swagger.json
+++ b/swagger/api_v3/query_service.swagger.json
@@ -128,8 +128,8 @@
             "type": "string"
           },
           {
-            "name": "query.search_depth",
-            "description": "search_depth defines the maximum search depth. Depending on the backend storage implementation,\nthis may behave like an SQL `LIMIT` clause. However, some implementations might not support\nprecise limits, and a larger value generally results in more traces being returned.",
+            "name": "query.num_traces",
+            "description": "num_traces defines the maximum search depth. Depending on the backend storage implementation,\nthis may behave like an SQL `LIMIT` clause. However, some implementations might not support\nprecise limits, and a larger value generally results in more traces being returned.",
             "in": "query",
             "required": false,
             "type": "integer",
@@ -141,6 +141,14 @@
             "in": "query",
             "required": false,
             "type": "boolean"
+          },
+          {
+            "name": "query.attributes",
+            "description": "attributes filters traces by span or resource attributes. Should be a JSON object of key-value pairs, e.g. {\"driver\":\"T751767C\"}.",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "example": "{\"driver\":\"T751767C\"}"
           }
         ],
         "tags": [


### PR DESCRIPTION
## Which problem is this PR solving?
 This PR is part of the solution for the issue- https://github.com/jaegertracing/jaeger/issues/7594

## Description of the changes
I noticed that attributes are not mentioned in [Swagger](https://github.com/jaegertracing/jaeger-idl/blob/main/swagger/api_v3/query_service.swagger.json) docs.
Also, when querying the traces, the limit was passed as "num_traces" instead of search_depth.
So I have done the appropriate changes to Swagger docs to make it consistent with the api.

## How was this change tested?
- 

## Checklist
- [x ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
