### PR TITLE
Document HTTP API format for attributes parameter and correct CONTRIBUTING.md error

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ make test-ci
 make lint
 ```
 
-## Making changes to the .proto files
+## Making changes to the .thrift files
 
 After making any changes to .thrift files make sure all generated files are up to date by running:
 ```

--- a/proto/api_v3/query_service.proto
+++ b/proto/api_v3/query_service.proto
@@ -59,6 +59,9 @@ message TraceQueryParameters {
   // attributes contains key-value pairs where the key is the attribute name
   // and the value is its string representation. Attributes are matched against
   // span and resource attributes. At least one span must match all specified attributes.
+  //
+  // The HTTP API expects this as a URL-encoded JSON string map.
+  // Example: {"http.status_code":"200","error":"true"}
   map<string, string> attributes = 3;
 
   // start_time_min is the start of the time interval (inclusive) for the query.

--- a/swagger/api_v3/query_service.swagger.json
+++ b/swagger/api_v3/query_service.swagger.json
@@ -348,7 +348,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "attributes contains key-value pairs where the key is the attribute name\nand the value is its string representation. Attributes are matched against\nspan and resource attributes. At least one span must match all specified attributes."
+          "description": "attributes contains key-value pairs where the key is the attribute name\nand the value is its string representation. Attributes are matched against\nspan and resource attributes. At least one span must match all specified attributes.\n\nThe HTTP API expects this as a URL-encoded JSON string map.\nExample: {\"http.status_code\":\"200\",\"error\":\"true\"}"
         },
         "start_time_min": {
           "type": "string",


### PR DESCRIPTION
## Which problem is this PR solving?
- Addresses maintainer question in jaegertracing/jaeger#7594 about documenting the HTTP API format for the attributes parameter

## Description of the changes
- Added documentation to `proto/api_v3/query_service.proto` specifying that the HTTP API expects the `attributes` parameter as a URL-encoded JSON string map
- Follows the same documentation pattern used for other fields like `start_time_min`
- Regenerated `swagger/api_v3/query_service.swagger.json` to reflect the updated documentation
- Example format: `{"http.status_code":"200","error":"true"}`
- Also fixed the CONTRIBUTING.md by correcting the title for thrift commands.

## How was this change tested?
- Ran `make proto-all` to regenerate all auto-generated files
- Verified swagger documentation was updated correctly
- Ran `make test-ci` - all tests passed

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality *(N/A - documentation only)*
- [x] I have run lint and test steps successfully
  - for `jaeger-idl`: `make proto-all test-ci`