### PR TITLE
Add query.attributes parameter to /api/v3/traces endpoint

### DIFF
--- a/swagger/api_v3/query_service.swagger.json
+++ b/swagger/api_v3/query_service.swagger.json
@@ -141,6 +141,13 @@
             "in": "query",
             "required": false,
             "type": "boolean"
+          },
+          {
+            "name": "query.attributes",
+            "description": "attributes contains key-value pairs where the key is the attribute name\nand the value is its string representation. Attributes are matched against\nspan and resource attributes. At least one span must match all specified attributes.\n\nThe HTTP API expects this as a URL-encoded JSON string map.\nExample: {\"http.status_code\":\"200\",\"error\":\"true\"}",
+            "in": "query",
+            "required": false,
+            "type": "string"
           }
         ],
         "tags": [


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #7594

## Description of the changes
- Added `query.attributes` support to the `/api/v3/traces` HTTP endpoint.

## How was this change tested?
- Verified with `http_gateway_test.go` and manual `curl` validation.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`