### PR TITLE
Add api_v3.GetDependencies

### DIFF
--- a/proto/api_v3/query_service.proto
+++ b/proto/api_v3/query_service.proto
@@ -144,6 +144,22 @@ message GetOperationsResponse {
   repeated Operation operations = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
+message GetDependenciesRequest {
+  google.protobuf.Timestamp end_time = 1;
+  google.protobuf.Duration lookback = 2;
+}
+
+message DependencyLink {
+  string parent = 1;
+  string child = 2;
+  uint64 call_count = 3;
+}
+
+message GetDependenciesResponse {
+  repeated DependencyLink dependencies = 1;
+}
+
+
 service QueryService {
   // GetTrace returns a single trace.
   // Note that the JSON response over HTTP is wrapped into result envelope "{"result": ...}"
@@ -190,6 +206,13 @@ service QueryService {
   rpc GetOperations(GetOperationsRequest) returns (GetOperationsResponse) {
     option (google.api.http) = {
       get: "/api/v3/operations"
+    };
+  }
+
+  // GetDependencies returns dependencies.
+  rpc GetDependencies(GetDependenciesRequest) returns (GetDependenciesResponse) {
+    option (google.api.http) = {
+      get: "/api/v3/dependencies"
     };
   }
 }

--- a/swagger/api_v3/query_service.openapi.yaml
+++ b/swagger/api_v3/query_service.openapi.yaml
@@ -6,6 +6,37 @@ info:
     title: QueryService API
     version: 0.0.1
 paths:
+    /api/v3/dependencies:
+        get:
+            tags:
+                - QueryService
+            description: GetDependencies returns dependencies.
+            operationId: QueryService_GetDependencies
+            parameters:
+                - name: end_time
+                  in: query
+                  schema:
+                    type: string
+                    format: date-time
+                - name: lookback
+                  in: query
+                  schema:
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                    type: string
+                    description: Represents a a duration between -315,576,000,000s and 315,576,000,000s (around 10000 years). Precision is in nanoseconds. 1 nanosecond is represented as 0.000000001s
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/jaeger.api_v3.GetDependenciesResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/google.rpc.Status'
     /api/v3/operations:
         get:
             tags:
@@ -254,12 +285,28 @@ components:
                         $ref: '#/components/schemas/google.protobuf.Any'
                     description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
             description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
+        jaeger.api_v3.DependencyLink:
+            type: object
+            properties:
+                parent:
+                    type: string
+                child:
+                    type: string
+                call_count:
+                    type: string
         jaeger.api_v3.FindTracesRequest:
             type: object
             properties:
                 query:
                     $ref: '#/components/schemas/jaeger.api_v3.TraceQueryParameters'
             description: Request object to search traces.
+        jaeger.api_v3.GetDependenciesResponse:
+            type: object
+            properties:
+                dependencies:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/jaeger.api_v3.DependencyLink'
         jaeger.api_v3.GetOperationsResponse:
             required:
                 - operations

--- a/swagger/api_v3/query_service.swagger.json
+++ b/swagger/api_v3/query_service.swagger.json
@@ -11,6 +11,38 @@
     "application/json"
   ],
   "paths": {
+    "/api/v3/dependencies": {
+      "get": {
+        "summary": "GetDependencies returns dependencies.",
+        "operationId": "QueryService_GetDependencies",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/api_v3GetDependenciesResponse"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "end_time",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "lookback",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "QueryService"
+        ]
+      }
+    },
     "/api/v3/operations": {
       "get": {
         "summary": "GetOperations returns operation names.",
@@ -293,6 +325,21 @@
       "description": "- STATUS_CODE_UNSET: The default status.\n - STATUS_CODE_OK: The Span has been validated by an Application developer or Operator to \nhave completed successfully.\n - STATUS_CODE_ERROR: The Span contains an error.",
       "title": "For the semantics of status codes see\nhttps://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status"
     },
+    "api_v3DependencyLink": {
+      "type": "object",
+      "properties": {
+        "parent": {
+          "type": "string"
+        },
+        "child": {
+          "type": "string"
+        },
+        "call_count": {
+          "type": "string",
+          "format": "uint64"
+        }
+      }
+    },
     "api_v3FindTracesRequest": {
       "type": "object",
       "properties": {
@@ -301,6 +348,17 @@
         }
       },
       "description": "Request object to search traces."
+    },
+    "api_v3GetDependenciesResponse": {
+      "type": "object",
+      "properties": {
+        "dependencies": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/api_v3DependencyLink"
+          }
+        }
+      }
     },
     "api_v3GetOperationsResponse": {
       "type": "object",


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
Partly Fixes [7595](https://github.com/jaegertracing/jaeger/issues/7595).

## Description of the changes
- Add `GetDependencies` RPC endpoint to Query Service API v3
- Add `GetDependenciesRequest` message with `end_time` and `lookback` parameters
- Add `GetDependenciesResponse` message with repeated `DependencyLink` entries
- Add `DependencyLink` message to represent parent-child service relationships with call counts
- Add HTTP GET mapping to `/api/v3/dependencies` endpoint
- Update OpenAPI/Swagger documentation

## How was this change tested?
- Protocol buffer definitions compiled successfully
- OpenAPI/Swagger files generated without errors
- Verified HTTP endpoint mapping follows existing patterns in the API

[jaeger related PR](https://github.com/jaegertracing/jaeger/pull/7894)

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
