### PR TITLE
Relax source compatibility level to Go 1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/jaegertracing/jaeger-idl
 
-go 1.26.0
+go 1.25.0
+
+toolchain go1.26.0
 
 require (
 	github.com/apache/thrift v0.23.0


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves https://github.com/jaegertracing/jaeger-idl/issues/198

## Description of the changes
- Use `toolchain: 1.25` to relax source compatibility level

## How was this change tested?
- CI
