### PR TITLE
docs(api_v2): fix comment to use search_depth instead of num_traces

### DIFF
--- a/proto-gen/api_v2/query.pb.go
+++ b/proto-gen/api_v2/query.pb.go
@@ -247,13 +247,13 @@ func (m *ArchiveTraceResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_ArchiveTraceResponse proto.InternalMessageInfo
 
-// Query parameters to find traces. Except for num_traces, all fields should be treated
+// Query parameters to find traces. Except for search_depth, all fields should be treated
 // as forming a conjunction, e.g., "service_name='X' AND operation_name='Y' AND ...".
 // All fields are matched against individual spans, not at the trace level.
 // The returned results contain traces where at least one span matches the conditions.
-// When num_traces results in fewer traces returned, there is no required ordering.
+// When search_depth results in fewer traces returned, there is no required ordering.
 //
-// Note: num_traces should restrict the number of traces returned, but not all backends
+// Note: search_depth should restrict the number of traces returned, but not all backends
 // interpret it this way. For instance, in Cassandra this limits the number of _spans_
 // that match the conditions, and the resulting number of traces can be less.
 //

--- a/proto-gen/api_v2/query.pb.go
+++ b/proto-gen/api_v2/query.pb.go
@@ -247,8 +247,8 @@ func (m *ArchiveTraceResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_ArchiveTraceResponse proto.InternalMessageInfo
 
-// Query parameters to find traces. Except for search_depth, all fields should be treated
-// as forming a conjunction, e.g., "service_name='X' AND operation_name='Y' AND ...".
+// Query parameters to find traces. Except for search_depth and raw_traces, all fields
+// should be treated as forming a conjunction, e.g., "service_name='X' AND operation_name='Y' AND ...".
 // All fields are matched against individual spans, not at the trace level.
 // The returned results contain traces where at least one span matches the conditions.
 // When search_depth results in fewer traces returned, there is no required ordering.

--- a/proto/api_v2/query.proto
+++ b/proto/api_v2/query.proto
@@ -83,13 +83,13 @@ message ArchiveTraceRequest {
 message ArchiveTraceResponse {
 }
 
-// Query parameters to find traces. Except for num_traces, all fields should be treated
+// Query parameters to find traces. Except for search_depth, all fields should be treated
 // as forming a conjunction, e.g., "service_name='X' AND operation_name='Y' AND ...".
 // All fields are matched against individual spans, not at the trace level.
 // The returned results contain traces where at least one span matches the conditions.
-// When num_traces results in fewer traces returned, there is no required ordering.
+// When search_depth results in fewer traces returned, there is no required ordering.
 //
-// Note: num_traces should restrict the number of traces returned, but not all backends
+// Note: search_depth should restrict the number of traces returned, but not all backends
 // interpret it this way. For instance, in Cassandra this limits the number of _spans_
 // that match the conditions, and the resulting number of traces can be less.
 //

--- a/proto/api_v2/query.proto
+++ b/proto/api_v2/query.proto
@@ -83,8 +83,8 @@ message ArchiveTraceRequest {
 message ArchiveTraceResponse {
 }
 
-// Query parameters to find traces. Except for search_depth, all fields should be treated
-// as forming a conjunction, e.g., "service_name='X' AND operation_name='Y' AND ...".
+// Query parameters to find traces. Except for search_depth and raw_traces, all fields
+// should be treated as forming a conjunction, e.g., "service_name='X' AND operation_name='Y' AND ...".
 // All fields are matched against individual spans, not at the trace level.
 // The returned results contain traces where at least one span matches the conditions.
 // When search_depth results in fewer traces returned, there is no required ordering.


### PR DESCRIPTION
## Summary

- Updates the `TraceQueryParameters` comment block in `proto/api_v2/query.proto` to reference the actual field name `search_depth` instead of the old name `num_traces`
- No wire change — cosmetic/documentation fix only
- The field itself has been `search_depth = 8` since v3 was introduced; only the surrounding prose comments were stale

## Related

Fixes part of jaegertracing/jaeger#8617 (the `jaeger-idl` portion only).

## Test plan

- [ ] No functional change; verify the comment text is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)