### PR TITLE
feat(api_v3): Mark trace_id and ServiceSummary.name as REQUIRED

### DIFF
--- a/proto/api_v3/query_service.proto
+++ b/proto/api_v3/query_service.proto
@@ -168,7 +168,7 @@ message Dependency {
 // what the UI renders as a coloured tag in the search results row.
 message ServiceSummary {
   // Name of the service.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = REQUIRED];
 
   // Number of spans attributed to this service in the trace.
   int32 span_count = 2;
@@ -184,7 +184,7 @@ message ServiceSummary {
 // suitable for display in search result lists.
 message TraceSummary {
   // Hex-encoded 128-bit trace ID.
-  string trace_id = 1;
+  string trace_id = 1 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the service that owns the root span.
   string root_service_name = 2;

--- a/swagger/api_v3/query_service.openapi.yaml
+++ b/swagger/api_v3/query_service.openapi.yaml
@@ -488,6 +488,8 @@ components:
                     type: string
             description: Operation encapsulates information about operation.
         jaeger.api_v3.ServiceSummary:
+            required:
+                - name
             type: object
             properties:
                 name:
@@ -590,6 +592,8 @@ components:
 
                  The results have no guaranteed ordering.
         jaeger.api_v3.TraceSummary:
+            required:
+                - traceId
             type: object
             properties:
                 traceId:


### PR DESCRIPTION
## Summary

- Add `[(google.api.field_behavior) = REQUIRED]` to `trace_id` in `TraceSummary`
- Add `[(google.api.field_behavior) = REQUIRED]` to `name` in `ServiceSummary`
- Regenerate `swagger/api_v3/query_service.openapi.yaml` (now emits `required: [traceId]` and `required: [name]`)

## Motivation

Without a `trace_id` a `TraceSummary` record is useless — there is nothing to link to. A `ServiceSummary` entry without a `name` is equally meaningless. These are the only fields in each message that semantically must be present.

The `field_behavior = REQUIRED` annotation flows through `protoc-gen-openapi` (gnostic) to emit a `required:` array in the OpenAPI YAML. This lets downstream OpenAPI client generators (e.g. `openapi-zod-client` used by Jaeger UI) produce correct non-optional types for these fields without post-processing workarounds.

## Test plan

- [ ] `make test-code-gen` passes (checks the YAML diff matches what's committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)