### PR TITLE
feat(query): Add pagination fields for RFC 0014 M1

### DIFF
--- a/proto/api_v3/query_service.proto
+++ b/proto/api_v3/query_service.proto
@@ -140,8 +140,10 @@ message TraceQueryParameters {
 // previous page stopped.
 message Pagination {
   // page_size bounds the number of results in one page. When zero it falls back to
-  // search_depth (and search_depth's own default).
-  uint32 page_size = 1;
+  // search_depth (and search_depth's own default). Required whenever Pagination is
+  // sent at all: a Pagination with no page_size is meaningless, so the caller must
+  // send it explicitly, even as zero, rather than omit it.
+  uint32 page_size = 1 [(google.api.field_behavior) = REQUIRED];
 
   // page_token continues a previous search. Empty starts a new one. The value is
   // opaque: clients MUST treat it as an uninterpreted cursor and echo back exactly
@@ -149,7 +151,7 @@ message Pagination {
   // is a protobuf string, the server MUST encode the token as valid UTF-8 text (for
   // example, unpadded base64url of the underlying cursor bytes). A token is only
   // valid for the same query that produced it.
-  string page_token = 2;
+  string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Request object to search traces.

--- a/proto/api_v3/query_service.proto
+++ b/proto/api_v3/query_service.proto
@@ -136,11 +136,14 @@ message TraceQueryParameters {
 message Pagination {
   // page_size bounds the number of results in one page. When zero it falls back to
   // search_depth (and search_depth's own default).
-  int32 page_size = 1;
+  uint32 page_size = 1;
 
   // page_token continues a previous search. Empty starts a new one. The value is
-  // opaque: clients MUST treat it as a blob and echo back exactly what the server
-  // returned. A token is only valid for the same query that produced it.
+  // opaque: clients MUST treat it as an uninterpreted cursor and echo back exactly
+  // what the server returned, without inspecting or modifying it. Because this field
+  // is a protobuf string, the server MUST encode the token as valid UTF-8 text (for
+  // example, unpadded base64url of the underlying cursor bytes). A token is only
+  // valid for the same query that produced it.
   string page_token = 2;
 }
 

--- a/proto/api_v3/query_service.proto
+++ b/proto/api_v3/query_service.proto
@@ -125,6 +125,23 @@ message TraceQueryParameters {
   // it is the structured Call. For example, the filter http.status_code == 500 is
   // {"op":"eq","args":[{"attr":{"key":"http.status_code"}},{"scalar":{"value":"500"}}]}
   jaeger.expression.v1.Call filter = 10;
+
+  // pagination requests a paginated search. When this field is absent the search
+  // behaves exactly as today: one page bounded by search_depth, no continuation.
+  Pagination pagination = 11;
+}
+
+// Pagination asks for one page of results and, on continuation, says where the
+// previous page stopped.
+message Pagination {
+  // page_size bounds the number of results in one page. When zero it falls back to
+  // search_depth (and search_depth's own default).
+  int32 page_size = 1;
+
+  // page_token continues a previous search. Empty starts a new one. The value is
+  // opaque: clients MUST treat it as a blob and echo back exactly what the server
+  // returned. A token is only valid for the same query that produced it.
+  string page_token = 2;
 }
 
 // Request object to search traces.
@@ -242,6 +259,11 @@ message FindTraceSummariesRequest {
 // used by FindTraces / GetTrace.
 message FindTraceSummariesResponse {
   repeated TraceSummary summaries = 1;
+
+  // next_page_token continues the search past this page. Set only on the final
+  // chunk of the stream; empty means there are no more pages. See
+  // TraceQueryParameters.pagination.
+  string next_page_token = 2;
 }
 
 service QueryService {

--- a/proto/api_v3/query_service.proto
+++ b/proto/api_v3/query_service.proto
@@ -140,10 +140,11 @@ message TraceQueryParameters {
 // previous page stopped.
 message Pagination {
   // page_size bounds the number of results in one page. When zero it falls back to
-  // search_depth (and search_depth's own default). Required whenever Pagination is
-  // sent at all: a Pagination with no page_size is meaningless, so the caller must
-  // send it explicitly, even as zero, rather than omit it.
-  uint32 page_size = 1 [(google.api.field_behavior) = REQUIRED];
+  // search_depth (and search_depth's own default), the same relationship search_depth
+  // itself documents. Not marked required: proto3 gives a plain scalar no wire-level
+  // presence, so "explicitly zero" and "omitted" are indistinguishable here, the same
+  // as for search_depth.
+  uint32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
 
   // page_token continues a previous search. Empty starts a new one. The value is
   // opaque: clients MUST treat it as an uninterpreted cursor and echo back exactly
@@ -271,7 +272,10 @@ message FindTraceSummariesResponse {
   repeated TraceSummary summaries = 1;
 
   // next_page_token continues the search past this page. Set only on the final
-  // chunk of the stream; empty means there are no more pages. See
+  // chunk of the stream. Empty means there are no more pages, but only when the
+  // backend actually supports pagination; a backend that does not (SearchCapabilities
+  // .paginated false) always returns an empty token here, even when matches remain,
+  // and serves a single page capped at page_size or search_depth. See
   // TraceQueryParameters.pagination.
   string next_page_token = 2;
 }

--- a/proto/api_v3/query_service.proto
+++ b/proto/api_v3/query_service.proto
@@ -126,32 +126,48 @@ message TraceQueryParameters {
   // {"op":"eq","args":[{"attr":{"key":"http.status_code"}},{"scalar":{"value":"500"}}]}
   jaeger.expression.v1.Call filter = 10;
 
-  // pagination requests a paginated search. When this field is absent the search
-  // behaves exactly as today: one page bounded by search_depth, no continuation.
-  //
-  // Only FindTraceSummaries returns a continuation token (FindTraceSummariesResponse.
-  // next_page_token); FindTraces streams opentelemetry.proto.trace.v1.TracesData, which has
-  // no room for one, so page_size still bounds a FindTraces call but the call itself cannot
-  // be resumed through this field.
+  // pagination requests a paginated search, see comments for Pagination.
+  // Mutually exclusive with search_depth. When this field is absent the search
+  // returns a single page bounded by search_depth and no continuation token.
   Pagination pagination = 11;
 }
 
 // Pagination asks for one page of results and, on continuation, says where the
 // previous page stopped.
+//
+// A paginated search returns at most page_size results, and when more matches
+// remain the response also carries a next_page_token. Sending that value back as
+// page_token in an otherwise identical request returns the page that follows, so
+// that a client walking the token chain sees every matching trace exactly once. An
+// empty next_page_token means the search is exhausted.
+//
+// Pagination replaces search_depth rather than refining it: the two are mutually
+// exclusive, and the query service rejects a request that sets both with
+// InvalidArgument.
+//
+// Only FindTraceSummaries paginates, returning the token on
+// FindTraceSummariesResponse. That is enough for a search screen, which walks the
+// summaries and fetches whole traces only for the rows a user opens. FindTraces
+// streams opentelemetry.proto.trace.v1.TracesData, an OTLP type with no field to
+// carry a token, so FindTraces is not paginated at all: the query service rejects
+// a FindTraces request that sets pagination with InvalidArgument, and search_depth
+// bounds such a call instead.
+//
+// Pagination needs backend support. A backend that cannot paginate, meaning
+// jaeger.storage.v2.SearchCapabilities.paginated is false, serves a single page
+// capped at page_size and returns an empty next_page_token even when matches
+// remain, and the query service rejects a request carrying a page_token with
+// InvalidArgument, since such a backend cannot have minted a valid token.
 message Pagination {
-  // page_size bounds the number of results in one page. When zero it falls back to
-  // search_depth (and search_depth's own default), the same relationship search_depth
-  // itself documents. Not marked required: proto3 gives a plain scalar no wire-level
-  // presence, so "explicitly zero" and "omitted" are indistinguishable here, the same
-  // as for search_depth.
-  uint32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // page_size bounds the number of results in one page. A Pagination that leaves it
+  // zero does not describe a page, and the query service rejects such a request
+  // with InvalidArgument.
+  uint32 page_size = 1 [(google.api.field_behavior) = REQUIRED];
 
-  // page_token continues a previous search. Empty starts a new one. The value is
-  // opaque: clients MUST treat it as an uninterpreted cursor and echo back exactly
-  // what the server returned, without inspecting or modifying it. Because this field
-  // is a protobuf string, the server MUST encode the token as valid UTF-8 text (for
-  // example, unpadded base64url of the underlying cursor bytes). A token is only
-  // valid for the same query that produced it.
+  // page_token is the next_page_token the server returned for the preceding page;
+  // empty starts a new search. The value is opaque, and a client MUST echo back
+  // exactly what the server returned without inspecting or modifying it. A token is
+  // only valid for the query that produced it.
   string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
@@ -271,12 +287,10 @@ message FindTraceSummariesRequest {
 message FindTraceSummariesResponse {
   repeated TraceSummary summaries = 1;
 
-  // next_page_token continues the search past this page. Set only on the final
-  // chunk of the stream. Empty means there are no more pages, but only when the
-  // backend actually supports pagination; a backend that does not (SearchCapabilities
-  // .paginated false) always returns an empty token here, even when matches remain,
-  // and serves a single page capped at page_size or search_depth. See
-  // TraceQueryParameters.pagination.
+  // next_page_token is the cursor the caller can send back as Pagination.page_token
+  // to fetch the page after this one, see comments for Pagination. The server sets
+  // it only on the final chunk of the stream, and leaves it empty there when
+  // this is the last page.
   string next_page_token = 2;
 }
 

--- a/proto/api_v3/query_service.proto
+++ b/proto/api_v3/query_service.proto
@@ -128,6 +128,11 @@ message TraceQueryParameters {
 
   // pagination requests a paginated search. When this field is absent the search
   // behaves exactly as today: one page bounded by search_depth, no continuation.
+  //
+  // Only FindTraceSummaries returns a continuation token (FindTraceSummariesResponse.
+  // next_page_token); FindTraces streams opentelemetry.proto.trace.v1.TracesData, which has
+  // no room for one, so page_size still bounds a FindTraces call but the call itself cannot
+  // be resumed through this field.
   Pagination pagination = 11;
 }
 

--- a/proto/storage/v2/capabilities.proto
+++ b/proto/storage/v2/capabilities.proto
@@ -33,6 +33,16 @@ message SearchCapabilities {
   // only by populating the lists below, and there is no distinct "present but empty"
   // state to get wrong.
   FilterCapabilities filter = 3;
+
+  // paginated is true when FindTraceIDs and FindTraceSummaries honor a request's
+  // Pagination and return a next_page_token that resumes the search exactly where
+  // the previous page stopped, visiting every matching trace once under a stable
+  // total ordering. Its zero value means the backend cannot paginate: the query
+  // service serves a single page capped at page_size/search_depth, returns an empty
+  // next_page_token even though matches may remain, and rejects a request that
+  // carries a page_token with InvalidArgument, since a backend that cannot paginate
+  // cannot have minted a valid cursor.
+  bool paginated = 4;
 }
 
 // FilterCapabilities declares how much of the structured trace-query filter a backend

--- a/proto/storage/v2/capabilities.proto
+++ b/proto/storage/v2/capabilities.proto
@@ -37,11 +37,8 @@ message SearchCapabilities {
   // paginated is true when FindTraceIDs and FindTraceSummaries honor a request's
   // Pagination and return a next_page_token that resumes the search exactly where
   // the previous page stopped, visiting every matching trace once under a stable
-  // total ordering. Its zero value means the backend cannot paginate: the query
-  // service serves a single page capped at page_size/search_depth, returns an empty
-  // next_page_token even though matches may remain, and rejects a request that
-  // carries a page_token with InvalidArgument, since a backend that cannot paginate
-  // cannot have minted a valid cursor.
+  // total ordering. Its zero value means the backend cannot paginate. See comments
+  // for Pagination in trace_storage.proto.
   bool paginated = 4;
 }
 

--- a/proto/storage/v2/trace_storage.proto
+++ b/proto/storage/v2/trace_storage.proto
@@ -112,31 +112,50 @@ message TraceQueryParameters {
   // default) and the backend declares support via SearchCapabilities.filter.
   jaeger.expression.v1.Call filter = 9;
 
-  // pagination requests a paginated search. When this field is absent the search
-  // behaves exactly as today: one page bounded by search_depth, no continuation.
-  //
-  // Only FindTraceIDs and FindTraceSummaries return a continuation token
-  // (next_page_token on their responses); FindTraces streams
-  // opentelemetry.proto.trace.v1.TracesData, which has no room for one, so page_size
-  // still bounds a FindTraces call but the call itself cannot be resumed through this
-  // field.
+  // pagination requests a paginated search, see comments for Pagination.
+  // Mutually exclusive with search_depth. When this field is absent the search
+  // returns a single page bounded by search_depth and no continuation token.
   Pagination pagination = 10;
 }
 
 // Pagination asks for one page of results and, on continuation, says where the
 // previous page stopped. Same shape as jaeger.api_v3.Pagination; duplicated here
 // because jaeger.storage.v2 does not import jaeger.api_v3.
+//
+// A paginated search returns at most page_size results, and when more matches
+// remain the response also carries a next_page_token. Sending that value back as
+// page_token in an otherwise identical request returns the page that follows, so
+// that a caller walking the token chain sees every matching trace exactly once. An
+// empty next_page_token means the search is exhausted.
+//
+// Pagination replaces search_depth rather than refining it: the two are mutually
+// exclusive, and a request that sets both is refused with InvalidArgument.
+//
+// Only FindTraceIDs and FindTraceSummaries paginate, returning the token on
+// FindTraceIDsResponse and FindTraceSummariesResponse. FindTraces streams
+// opentelemetry.proto.trace.v1.TracesData, an OTLP type with no field to carry a
+// token, so FindTraces is not paginated at all: a FindTraces request that sets
+// pagination is refused with InvalidArgument, and search_depth bounds such a call
+// instead.
+//
+// A backend should only honor a Pagination if it declares
+// SearchCapabilities.paginated. One that does not serves a single page capped at
+// page_size and returns an empty next_page_token even when matches remain, and
+// refuses a request carrying a page_token with InvalidArgument, since it cannot
+// have minted a valid token.
 message Pagination {
-  // page_size bounds the number of results in one page. When zero it falls back to
-  // search_depth (and search_depth's own default).
+  // page_size bounds the number of results in one page. A Pagination that leaves it
+  // zero does not describe a page and is refused with InvalidArgument.
+  //
+  // This field is required.
   uint32 page_size = 1;
 
-  // page_token continues a previous search. Empty starts a new one. The value is
-  // opaque: clients MUST treat it as an uninterpreted cursor and echo back exactly
-  // what the server returned, without inspecting or modifying it. Because this field
-  // is a protobuf string, the server MUST encode the token as valid UTF-8 text (for
-  // example, unpadded base64url of the underlying cursor bytes). A token is only
-  // valid for the same query that produced it.
+  // page_token is the next_page_token returned for the preceding page; empty starts
+  // a new search. The value is opaque, and a caller MUST echo back exactly what the
+  // backend returned without inspecting or modifying it. A token is only valid for
+  // the query that produced it.
+  //
+  // This field is optional.
   string page_token = 2;
 }
 
@@ -167,11 +186,9 @@ message FoundTraceID {
 message FindTraceIDsResponse {
   repeated FoundTraceID trace_ids = 1;
 
-  // next_page_token continues the search past this page. Empty means there are no
-  // more pages, but only when the backend actually supports pagination; a backend
-  // that does not (SearchCapabilities.paginated false) always returns an empty token
-  // here, even when matches remain, and serves a single page capped at page_size or
-  // search_depth. See TraceQueryParameters.pagination.
+  // next_page_token is the cursor the caller can send back as Pagination.page_token
+  // to fetch the page after this one, see comments for Pagination. The backend
+  // leaves it empty when this is the last page.
   string next_page_token = 2;
 }
 
@@ -208,12 +225,10 @@ message FindTraceSummariesRequest {
 message FindTraceSummariesResponse {
   repeated TraceSummary summaries = 1;
 
-  // next_page_token continues the search past this page. Set only on the final
-  // chunk of the stream. Empty means there are no more pages, but only when the
-  // backend actually supports pagination; a backend that does not (SearchCapabilities
-  // .paginated false) always returns an empty token here, even when matches remain,
-  // and serves a single page capped at page_size or search_depth. See
-  // TraceQueryParameters.pagination.
+  // next_page_token is the cursor the caller can send back as Pagination.page_token
+  // to fetch the page after this one, see comments for Pagination. The backend sets
+  // it only on the final chunk of the stream, and leaves it empty there when
+  // this is the last page.
   string next_page_token = 2;
 }
 

--- a/proto/storage/v2/trace_storage.proto
+++ b/proto/storage/v2/trace_storage.proto
@@ -168,7 +168,10 @@ message FindTraceIDsResponse {
   repeated FoundTraceID trace_ids = 1;
 
   // next_page_token continues the search past this page. Empty means there are no
-  // more pages. See TraceQueryParameters.pagination.
+  // more pages, but only when the backend actually supports pagination; a backend
+  // that does not (SearchCapabilities.paginated false) always returns an empty token
+  // here, even when matches remain, and serves a single page capped at page_size or
+  // search_depth. See TraceQueryParameters.pagination.
   string next_page_token = 2;
 }
 
@@ -206,7 +209,10 @@ message FindTraceSummariesResponse {
   repeated TraceSummary summaries = 1;
 
   // next_page_token continues the search past this page. Set only on the final
-  // chunk of the stream; empty means there are no more pages. See
+  // chunk of the stream. Empty means there are no more pages, but only when the
+  // backend actually supports pagination; a backend that does not (SearchCapabilities
+  // .paginated false) always returns an empty token here, even when matches remain,
+  // and serves a single page capped at page_size or search_depth. See
   // TraceQueryParameters.pagination.
   string next_page_token = 2;
 }

--- a/proto/storage/v2/trace_storage.proto
+++ b/proto/storage/v2/trace_storage.proto
@@ -111,6 +111,24 @@ message TraceQueryParameters {
   // has the `jaeger.query.structuredFilters` feature gate enabled (Alpha, off by
   // default) and the backend declares support via SearchCapabilities.filter.
   jaeger.expression.v1.Call filter = 9;
+
+  // pagination requests a paginated search. When this field is absent the search
+  // behaves exactly as today: one page bounded by search_depth, no continuation.
+  Pagination pagination = 10;
+}
+
+// Pagination asks for one page of results and, on continuation, says where the
+// previous page stopped. Same shape as jaeger.api_v3.Pagination; duplicated here
+// because jaeger.storage.v2 does not import jaeger.api_v3.
+message Pagination {
+  // page_size bounds the number of results in one page. When zero it falls back to
+  // search_depth (and search_depth's own default).
+  int32 page_size = 1;
+
+  // page_token continues a previous search. Empty starts a new one. The value is
+  // opaque: clients MUST treat it as a blob and echo back exactly what the server
+  // returned. A token is only valid for the same query that produced it.
+  string page_token = 2;
 }
 
 // FindTracesRequest represents a request to find traces.
@@ -139,6 +157,10 @@ message FoundTraceID {
 // FindTraceIDsResponse represents the response for FindTraceIDsRequest.
 message FindTraceIDsResponse {
   repeated FoundTraceID trace_ids = 1;
+
+  // next_page_token continues the search past this page. Empty means there are no
+  // more pages. See TraceQueryParameters.pagination.
+  string next_page_token = 2;
 }
 
 // ServiceSummary contains per-service statistics for a trace.
@@ -173,6 +195,11 @@ message FindTraceSummariesRequest {
 // Mirrors the chunked streaming contract of GetTraces / FindTraces.
 message FindTraceSummariesResponse {
   repeated TraceSummary summaries = 1;
+
+  // next_page_token continues the search past this page. Set only on the final
+  // chunk of the stream; empty means there are no more pages. See
+  // TraceQueryParameters.pagination.
+  string next_page_token = 2;
 }
 
 // TraceReader is a service that allows reading traces from storage.

--- a/proto/storage/v2/trace_storage.proto
+++ b/proto/storage/v2/trace_storage.proto
@@ -123,11 +123,14 @@ message TraceQueryParameters {
 message Pagination {
   // page_size bounds the number of results in one page. When zero it falls back to
   // search_depth (and search_depth's own default).
-  int32 page_size = 1;
+  uint32 page_size = 1;
 
   // page_token continues a previous search. Empty starts a new one. The value is
-  // opaque: clients MUST treat it as a blob and echo back exactly what the server
-  // returned. A token is only valid for the same query that produced it.
+  // opaque: clients MUST treat it as an uninterpreted cursor and echo back exactly
+  // what the server returned, without inspecting or modifying it. Because this field
+  // is a protobuf string, the server MUST encode the token as valid UTF-8 text (for
+  // example, unpadded base64url of the underlying cursor bytes). A token is only
+  // valid for the same query that produced it.
   string page_token = 2;
 }
 

--- a/proto/storage/v2/trace_storage.proto
+++ b/proto/storage/v2/trace_storage.proto
@@ -114,6 +114,12 @@ message TraceQueryParameters {
 
   // pagination requests a paginated search. When this field is absent the search
   // behaves exactly as today: one page bounded by search_depth, no continuation.
+  //
+  // Only FindTraceIDs and FindTraceSummaries return a continuation token
+  // (next_page_token on their responses); FindTraces streams
+  // opentelemetry.proto.trace.v1.TracesData, which has no room for one, so page_size
+  // still bounds a FindTraces call but the call itself cannot be resumed through this
+  // field.
   Pagination pagination = 10;
 }
 

--- a/swagger/api_v3/query_service.openapi.json
+++ b/swagger/api_v3/query_service.openapi.json
@@ -80,7 +80,7 @@
         "description": "Response chunk for FindTraceSummaries. A single RPC call may yield multiple\n chunks, each carrying one or more summaries, mirroring the chunked streaming\n used by FindTraces / GetTrace.",
         "properties": {
           "nextPageToken": {
-            "description": "next_page_token continues the search past this page. Set only on the final\n chunk of the stream. Empty means there are no more pages, but only when the\n backend actually supports pagination; a backend that does not (SearchCapabilities\n .paginated false) always returns an empty token here, even when matches remain,\n and serves a single page capped at page_size or search_depth. See\n TraceQueryParameters.pagination.",
+            "description": "next_page_token is the cursor the caller can send back as Pagination.page_token\n to fetch the page after this one, see comments for Pagination. The server sets\n it only on the final chunk of the stream, and leaves it empty there when\n this is the last page.",
             "type": "string"
           },
           "summaries": {
@@ -148,18 +148,21 @@
         "type": "object"
       },
       "jaeger.api_v3.Pagination": {
-        "description": "Pagination asks for one page of results and, on continuation, says where the\n previous page stopped.",
+        "description": "Pagination asks for one page of results and, on continuation, says where the\n previous page stopped.\n\n A paginated search returns at most page_size results, and when more matches\n remain the response also carries a next_page_token. Sending that value back as\n page_token in an otherwise identical request returns the page that follows, so\n that a client walking the token chain sees every matching trace exactly once. An\n empty next_page_token means the search is exhausted.\n\n Pagination replaces search_depth rather than refining it: the two are mutually\n exclusive, and the query service rejects a request that sets both with\n InvalidArgument.\n\n Only FindTraceSummaries paginates, returning the token on\n FindTraceSummariesResponse. That is enough for a search screen, which walks the\n summaries and fetches whole traces only for the rows a user opens. FindTraces\n streams opentelemetry.proto.trace.v1.TracesData, an OTLP type with no field to\n carry a token, so FindTraces is not paginated at all: the query service rejects\n a FindTraces request that sets pagination with InvalidArgument, and search_depth\n bounds such a call instead.\n\n Pagination needs backend support. A backend that cannot paginate, meaning\n jaeger.storage.v2.SearchCapabilities.paginated is false, serves a single page\n capped at page_size and returns an empty next_page_token even when matches\n remain, and the query service rejects a request carrying a page_token with\n InvalidArgument, since such a backend cannot have minted a valid token.",
         "properties": {
           "pageSize": {
-            "description": "page_size bounds the number of results in one page. When zero it falls back to\n search_depth (and search_depth's own default), the same relationship search_depth\n itself documents. Not marked required: proto3 gives a plain scalar no wire-level\n presence, so \"explicitly zero\" and \"omitted\" are indistinguishable here, the same\n as for search_depth.",
+            "description": "page_size bounds the number of results in one page. A Pagination that leaves it\n zero does not describe a page, and the query service rejects such a request\n with InvalidArgument.",
             "format": "uint32",
             "type": "integer"
           },
           "pageToken": {
-            "description": "page_token continues a previous search. Empty starts a new one. The value is\n opaque: clients MUST treat it as an uninterpreted cursor and echo back exactly\n what the server returned, without inspecting or modifying it. Because this field\n is a protobuf string, the server MUST encode the token as valid UTF-8 text (for\n example, unpadded base64url of the underlying cursor bytes). A token is only\n valid for the same query that produced it.",
+            "description": "page_token is the next_page_token the server returned for the preceding page;\n empty starts a new search. The value is opaque, and a client MUST echo back\n exactly what the server returned without inspecting or modifying it. A token is\n only valid for the query that produced it.",
             "type": "string"
           }
         },
+        "required": [
+          "pageSize"
+        ],
         "type": "object"
       },
       "jaeger.api_v3.ServiceSummary": {
@@ -224,7 +227,7 @@
                 "$ref": "#/components/schemas/jaeger.api_v3.Pagination"
               }
             ],
-            "description": "pagination requests a paginated search. When this field is absent the search\n behaves exactly as today: one page bounded by search_depth, no continuation.\n\n Only FindTraceSummaries returns a continuation token (FindTraceSummariesResponse.\n next_page_token); FindTraces streams opentelemetry.proto.trace.v1.TracesData, which has\n no room for one, so page_size still bounds a FindTraces call but the call itself cannot\n be resumed through this field."
+            "description": "pagination requests a paginated search, see comments for Pagination.\n Mutually exclusive with search_depth. When this field is absent the search\n returns a single page bounded by search_depth and no continuation token."
           },
           "rawTraces": {
             "description": "If set to true, the response will exclude any enrichments to the trace, such as clock skew adjustments.\n The trace will be returned exactly as stored.\n\n This field is optional.",
@@ -1067,7 +1070,7 @@
             }
           },
           {
-            "description": "page_size bounds the number of results in one page. When zero it falls back to\n search_depth (and search_depth's own default), the same relationship search_depth\n itself documents. Not marked required: proto3 gives a plain scalar no wire-level\n presence, so \"explicitly zero\" and \"omitted\" are indistinguishable here, the same\n as for search_depth.",
+            "description": "page_size bounds the number of results in one page. A Pagination that leaves it\n zero does not describe a page, and the query service rejects such a request\n with InvalidArgument.",
             "in": "query",
             "name": "query.pagination.pageSize",
             "schema": {
@@ -1076,7 +1079,7 @@
             }
           },
           {
-            "description": "page_token continues a previous search. Empty starts a new one. The value is\n opaque: clients MUST treat it as an uninterpreted cursor and echo back exactly\n what the server returned, without inspecting or modifying it. Because this field\n is a protobuf string, the server MUST encode the token as valid UTF-8 text (for\n example, unpadded base64url of the underlying cursor bytes). A token is only\n valid for the same query that produced it.",
+            "description": "page_token is the next_page_token the server returned for the preceding page;\n empty starts a new search. The value is opaque, and a client MUST echo back\n exactly what the server returned without inspecting or modifying it. A token is\n only valid for the query that produced it.",
             "in": "query",
             "name": "query.pagination.pageToken",
             "schema": {
@@ -1236,7 +1239,7 @@
             }
           },
           {
-            "description": "page_size bounds the number of results in one page. When zero it falls back to\n search_depth (and search_depth's own default), the same relationship search_depth\n itself documents. Not marked required: proto3 gives a plain scalar no wire-level\n presence, so \"explicitly zero\" and \"omitted\" are indistinguishable here, the same\n as for search_depth.",
+            "description": "page_size bounds the number of results in one page. A Pagination that leaves it\n zero does not describe a page, and the query service rejects such a request\n with InvalidArgument.",
             "in": "query",
             "name": "query.pagination.pageSize",
             "schema": {
@@ -1245,7 +1248,7 @@
             }
           },
           {
-            "description": "page_token continues a previous search. Empty starts a new one. The value is\n opaque: clients MUST treat it as an uninterpreted cursor and echo back exactly\n what the server returned, without inspecting or modifying it. Because this field\n is a protobuf string, the server MUST encode the token as valid UTF-8 text (for\n example, unpadded base64url of the underlying cursor bytes). A token is only\n valid for the same query that produced it.",
+            "description": "page_token is the next_page_token the server returned for the preceding page;\n empty starts a new search. The value is opaque, and a client MUST echo back\n exactly what the server returned without inspecting or modifying it. A token is\n only valid for the query that produced it.",
             "in": "query",
             "name": "query.pagination.pageToken",
             "schema": {

--- a/swagger/api_v3/query_service.openapi.json
+++ b/swagger/api_v3/query_service.openapi.json
@@ -79,6 +79,10 @@
       "jaeger.api_v3.FindTraceSummariesResponse": {
         "description": "Response chunk for FindTraceSummaries. A single RPC call may yield multiple\n chunks, each carrying one or more summaries, mirroring the chunked streaming\n used by FindTraces / GetTrace.",
         "properties": {
+          "nextPageToken": {
+            "description": "next_page_token continues the search past this page. Set only on the final\n chunk of the stream; empty means there are no more pages. See\n TraceQueryParameters.pagination.",
+            "type": "string"
+          },
           "summaries": {
             "items": {
               "$ref": "#/components/schemas/jaeger.api_v3.TraceSummary"
@@ -143,6 +147,24 @@
         ],
         "type": "object"
       },
+      "jaeger.api_v3.Pagination": {
+        "description": "Pagination asks for one page of results and, on continuation, says where the\n previous page stopped.",
+        "properties": {
+          "pageSize": {
+            "description": "page_size bounds the number of results in one page. When zero it falls back to\n search_depth (and search_depth's own default). Required whenever Pagination is\n sent at all: a Pagination with no page_size is meaningless, so the caller must\n send it explicitly, even as zero, rather than omit it.",
+            "format": "uint32",
+            "type": "integer"
+          },
+          "pageToken": {
+            "description": "page_token continues a previous search. Empty starts a new one. The value is\n opaque: clients MUST treat it as an uninterpreted cursor and echo back exactly\n what the server returned, without inspecting or modifying it. Because this field\n is a protobuf string, the server MUST encode the token as valid UTF-8 text (for\n example, unpadded base64url of the underlying cursor bytes). A token is only\n valid for the same query that produced it.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "pageSize"
+        ],
+        "type": "object"
+      },
       "jaeger.api_v3.ServiceSummary": {
         "description": "ServiceSummary contains per-service statistics for a trace, matching\n what the UI renders as a coloured tag in the search results row.",
         "properties": {
@@ -198,6 +220,14 @@
           "operationName": {
             "description": "operation_name filters spans by a specific operation / span name.",
             "type": "string"
+          },
+          "pagination": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/jaeger.api_v3.Pagination"
+              }
+            ],
+            "description": "pagination requests a paginated search. When this field is absent the search\n behaves exactly as today: one page bounded by search_depth, no continuation.\n\n Only FindTraceSummaries returns a continuation token (FindTraceSummariesResponse.\n next_page_token); FindTraces streams opentelemetry.proto.trace.v1.TracesData, which has\n no room for one, so page_size still bounds a FindTraces call but the call itself cannot\n be resumed through this field."
           },
           "rawTraces": {
             "description": "If set to true, the response will exclude any enrichments to the trace, such as clock skew adjustments.\n The trace will be returned exactly as stored.\n\n This field is optional.",
@@ -1040,6 +1070,23 @@
             }
           },
           {
+            "description": "page_size bounds the number of results in one page. When zero it falls back to\n search_depth (and search_depth's own default). Required whenever Pagination is\n sent at all: a Pagination with no page_size is meaningless, so the caller must\n send it explicitly, even as zero, rather than omit it.",
+            "in": "query",
+            "name": "query.pagination.pageSize",
+            "schema": {
+              "format": "uint32",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "page_token continues a previous search. Empty starts a new one. The value is\n opaque: clients MUST treat it as an uninterpreted cursor and echo back exactly\n what the server returned, without inspecting or modifying it. Because this field\n is a protobuf string, the server MUST encode the token as valid UTF-8 text (for\n example, unpadded base64url of the underlying cursor bytes). A token is only\n valid for the same query that produced it.",
+            "in": "query",
+            "name": "query.pagination.pageToken",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "description": "Structured query filter as a URL-encoded JSON object (a Call expression). See RFC 0005 §6.",
             "in": "query",
             "name": "query.filter",
@@ -1189,6 +1236,23 @@
             "name": "query.rawTraces",
             "schema": {
               "type": "boolean"
+            }
+          },
+          {
+            "description": "page_size bounds the number of results in one page. When zero it falls back to\n search_depth (and search_depth's own default). Required whenever Pagination is\n sent at all: a Pagination with no page_size is meaningless, so the caller must\n send it explicitly, even as zero, rather than omit it.",
+            "in": "query",
+            "name": "query.pagination.pageSize",
+            "schema": {
+              "format": "uint32",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "page_token continues a previous search. Empty starts a new one. The value is\n opaque: clients MUST treat it as an uninterpreted cursor and echo back exactly\n what the server returned, without inspecting or modifying it. Because this field\n is a protobuf string, the server MUST encode the token as valid UTF-8 text (for\n example, unpadded base64url of the underlying cursor bytes). A token is only\n valid for the same query that produced it.",
+            "in": "query",
+            "name": "query.pagination.pageToken",
+            "schema": {
+              "type": "string"
             }
           },
           {

--- a/swagger/api_v3/query_service.openapi.json
+++ b/swagger/api_v3/query_service.openapi.json
@@ -80,7 +80,7 @@
         "description": "Response chunk for FindTraceSummaries. A single RPC call may yield multiple\n chunks, each carrying one or more summaries, mirroring the chunked streaming\n used by FindTraces / GetTrace.",
         "properties": {
           "nextPageToken": {
-            "description": "next_page_token continues the search past this page. Set only on the final\n chunk of the stream; empty means there are no more pages. See\n TraceQueryParameters.pagination.",
+            "description": "next_page_token continues the search past this page. Set only on the final\n chunk of the stream. Empty means there are no more pages, but only when the\n backend actually supports pagination; a backend that does not (SearchCapabilities\n .paginated false) always returns an empty token here, even when matches remain,\n and serves a single page capped at page_size or search_depth. See\n TraceQueryParameters.pagination.",
             "type": "string"
           },
           "summaries": {
@@ -151,7 +151,7 @@
         "description": "Pagination asks for one page of results and, on continuation, says where the\n previous page stopped.",
         "properties": {
           "pageSize": {
-            "description": "page_size bounds the number of results in one page. When zero it falls back to\n search_depth (and search_depth's own default). Required whenever Pagination is\n sent at all: a Pagination with no page_size is meaningless, so the caller must\n send it explicitly, even as zero, rather than omit it.",
+            "description": "page_size bounds the number of results in one page. When zero it falls back to\n search_depth (and search_depth's own default), the same relationship search_depth\n itself documents. Not marked required: proto3 gives a plain scalar no wire-level\n presence, so \"explicitly zero\" and \"omitted\" are indistinguishable here, the same\n as for search_depth.",
             "format": "uint32",
             "type": "integer"
           },
@@ -160,9 +160,6 @@
             "type": "string"
           }
         },
-        "required": [
-          "pageSize"
-        ],
         "type": "object"
       },
       "jaeger.api_v3.ServiceSummary": {
@@ -1070,7 +1067,7 @@
             }
           },
           {
-            "description": "page_size bounds the number of results in one page. When zero it falls back to\n search_depth (and search_depth's own default). Required whenever Pagination is\n sent at all: a Pagination with no page_size is meaningless, so the caller must\n send it explicitly, even as zero, rather than omit it.",
+            "description": "page_size bounds the number of results in one page. When zero it falls back to\n search_depth (and search_depth's own default), the same relationship search_depth\n itself documents. Not marked required: proto3 gives a plain scalar no wire-level\n presence, so \"explicitly zero\" and \"omitted\" are indistinguishable here, the same\n as for search_depth.",
             "in": "query",
             "name": "query.pagination.pageSize",
             "schema": {
@@ -1239,7 +1236,7 @@
             }
           },
           {
-            "description": "page_size bounds the number of results in one page. When zero it falls back to\n search_depth (and search_depth's own default). Required whenever Pagination is\n sent at all: a Pagination with no page_size is meaningless, so the caller must\n send it explicitly, even as zero, rather than omit it.",
+            "description": "page_size bounds the number of results in one page. When zero it falls back to\n search_depth (and search_depth's own default), the same relationship search_depth\n itself documents. Not marked required: proto3 gives a plain scalar no wire-level\n presence, so \"explicitly zero\" and \"omitted\" are indistinguishable here, the same\n as for search_depth.",
             "in": "query",
             "name": "query.pagination.pageSize",
             "schema": {

--- a/swagger/api_v3/query_service.openapi.yaml
+++ b/swagger/api_v3/query_service.openapi.yaml
@@ -174,23 +174,19 @@ paths:
                 - name: query.pagination.pageSize
                   in: query
                   description: |-
-                    page_size bounds the number of results in one page. When zero it falls back to
-                     search_depth (and search_depth's own default), the same relationship search_depth
-                     itself documents. Not marked required: proto3 gives a plain scalar no wire-level
-                     presence, so "explicitly zero" and "omitted" are indistinguishable here, the same
-                     as for search_depth.
+                    page_size bounds the number of results in one page. A Pagination that leaves it
+                     zero does not describe a page, and the query service rejects such a request
+                     with InvalidArgument.
                   schema:
                     type: integer
                     format: uint32
                 - name: query.pagination.pageToken
                   in: query
                   description: |-
-                    page_token continues a previous search. Empty starts a new one. The value is
-                     opaque: clients MUST treat it as an uninterpreted cursor and echo back exactly
-                     what the server returned, without inspecting or modifying it. Because this field
-                     is a protobuf string, the server MUST encode the token as valid UTF-8 text (for
-                     example, unpadded base64url of the underlying cursor bytes). A token is only
-                     valid for the same query that produced it.
+                    page_token is the next_page_token the server returned for the preceding page;
+                     empty starts a new search. The value is opaque, and a client MUST echo back
+                     exactly what the server returned without inspecting or modifying it. A token is
+                     only valid for the query that produced it.
                   schema:
                     type: string
                 - name: query.filter
@@ -326,23 +322,19 @@ paths:
                 - name: query.pagination.pageSize
                   in: query
                   description: |-
-                    page_size bounds the number of results in one page. When zero it falls back to
-                     search_depth (and search_depth's own default), the same relationship search_depth
-                     itself documents. Not marked required: proto3 gives a plain scalar no wire-level
-                     presence, so "explicitly zero" and "omitted" are indistinguishable here, the same
-                     as for search_depth.
+                    page_size bounds the number of results in one page. A Pagination that leaves it
+                     zero does not describe a page, and the query service rejects such a request
+                     with InvalidArgument.
                   schema:
                     type: integer
                     format: uint32
                 - name: query.pagination.pageToken
                   in: query
                   description: |-
-                    page_token continues a previous search. Empty starts a new one. The value is
-                     opaque: clients MUST treat it as an uninterpreted cursor and echo back exactly
-                     what the server returned, without inspecting or modifying it. Because this field
-                     is a protobuf string, the server MUST encode the token as valid UTF-8 text (for
-                     example, unpadded base64url of the underlying cursor bytes). A token is only
-                     valid for the same query that produced it.
+                    page_token is the next_page_token the server returned for the preceding page;
+                     empty starts a new search. The value is opaque, and a client MUST echo back
+                     exactly what the server returned without inspecting or modifying it. A token is
+                     only valid for the query that produced it.
                   schema:
                     type: string
                 - name: query.filter
@@ -505,12 +497,10 @@ components:
                 nextPageToken:
                     type: string
                     description: |-
-                        next_page_token continues the search past this page. Set only on the final
-                         chunk of the stream. Empty means there are no more pages, but only when the
-                         backend actually supports pagination; a backend that does not (SearchCapabilities
-                         .paginated false) always returns an empty token here, even when matches remain,
-                         and serves a single page capped at page_size or search_depth. See
-                         TraceQueryParameters.pagination.
+                        next_page_token is the cursor the caller can send back as Pagination.page_token
+                         to fetch the page after this one, see comments for Pagination. The server sets
+                         it only on the final chunk of the stream, and leaves it empty there when
+                         this is the last page.
             description: |-
                 Response chunk for FindTraceSummaries. A single RPC call may yield multiple
                  chunks, each carrying one or more summaries, mirroring the chunked streaming
@@ -553,29 +543,51 @@ components:
                     type: string
             description: Operation encapsulates information about operation.
         jaeger.api_v3.Pagination:
+            required:
+                - pageSize
             type: object
             properties:
                 pageSize:
                     type: integer
                     description: |-
-                        page_size bounds the number of results in one page. When zero it falls back to
-                         search_depth (and search_depth's own default), the same relationship search_depth
-                         itself documents. Not marked required: proto3 gives a plain scalar no wire-level
-                         presence, so "explicitly zero" and "omitted" are indistinguishable here, the same
-                         as for search_depth.
+                        page_size bounds the number of results in one page. A Pagination that leaves it
+                         zero does not describe a page, and the query service rejects such a request
+                         with InvalidArgument.
                     format: uint32
                 pageToken:
                     type: string
                     description: |-
-                        page_token continues a previous search. Empty starts a new one. The value is
-                         opaque: clients MUST treat it as an uninterpreted cursor and echo back exactly
-                         what the server returned, without inspecting or modifying it. Because this field
-                         is a protobuf string, the server MUST encode the token as valid UTF-8 text (for
-                         example, unpadded base64url of the underlying cursor bytes). A token is only
-                         valid for the same query that produced it.
+                        page_token is the next_page_token the server returned for the preceding page;
+                         empty starts a new search. The value is opaque, and a client MUST echo back
+                         exactly what the server returned without inspecting or modifying it. A token is
+                         only valid for the query that produced it.
             description: |-
                 Pagination asks for one page of results and, on continuation, says where the
                  previous page stopped.
+
+                 A paginated search returns at most page_size results, and when more matches
+                 remain the response also carries a next_page_token. Sending that value back as
+                 page_token in an otherwise identical request returns the page that follows, so
+                 that a client walking the token chain sees every matching trace exactly once. An
+                 empty next_page_token means the search is exhausted.
+
+                 Pagination replaces search_depth rather than refining it: the two are mutually
+                 exclusive, and the query service rejects a request that sets both with
+                 InvalidArgument.
+
+                 Only FindTraceSummaries paginates, returning the token on
+                 FindTraceSummariesResponse. That is enough for a search screen, which walks the
+                 summaries and fetches whole traces only for the rows a user opens. FindTraces
+                 streams opentelemetry.proto.trace.v1.TracesData, an OTLP type with no field to
+                 carry a token, so FindTraces is not paginated at all: the query service rejects
+                 a FindTraces request that sets pagination with InvalidArgument, and search_depth
+                 bounds such a call instead.
+
+                 Pagination needs backend support. A backend that cannot paginate, meaning
+                 jaeger.storage.v2.SearchCapabilities.paginated is false, serves a single page
+                 capped at page_size and returns an empty next_page_token even when matches
+                 remain, and the query service rejects a request carrying a page_token with
+                 InvalidArgument, since such a backend cannot have minted a valid token.
         jaeger.api_v3.ServiceSummary:
             required:
                 - name
@@ -690,13 +702,9 @@ components:
                     allOf:
                         - $ref: '#/components/schemas/jaeger.api_v3.Pagination'
                     description: |-
-                        pagination requests a paginated search. When this field is absent the search
-                         behaves exactly as today: one page bounded by search_depth, no continuation.
-
-                         Only FindTraceSummaries returns a continuation token (FindTraceSummariesResponse.
-                         next_page_token); FindTraces streams opentelemetry.proto.trace.v1.TracesData, which has
-                         no room for one, so page_size still bounds a FindTraces call but the call itself cannot
-                         be resumed through this field.
+                        pagination requests a paginated search, see comments for Pagination.
+                         Mutually exclusive with search_depth. When this field is absent the search
+                         returns a single page bounded by search_depth and no continuation token.
             description: |-
                 Query parameters to find traces.
 

--- a/swagger/api_v3/query_service.openapi.yaml
+++ b/swagger/api_v3/query_service.openapi.yaml
@@ -175,9 +175,10 @@ paths:
                   in: query
                   description: |-
                     page_size bounds the number of results in one page. When zero it falls back to
-                     search_depth (and search_depth's own default). Required whenever Pagination is
-                     sent at all: a Pagination with no page_size is meaningless, so the caller must
-                     send it explicitly, even as zero, rather than omit it.
+                     search_depth (and search_depth's own default), the same relationship search_depth
+                     itself documents. Not marked required: proto3 gives a plain scalar no wire-level
+                     presence, so "explicitly zero" and "omitted" are indistinguishable here, the same
+                     as for search_depth.
                   schema:
                     type: integer
                     format: uint32
@@ -326,9 +327,10 @@ paths:
                   in: query
                   description: |-
                     page_size bounds the number of results in one page. When zero it falls back to
-                     search_depth (and search_depth's own default). Required whenever Pagination is
-                     sent at all: a Pagination with no page_size is meaningless, so the caller must
-                     send it explicitly, even as zero, rather than omit it.
+                     search_depth (and search_depth's own default), the same relationship search_depth
+                     itself documents. Not marked required: proto3 gives a plain scalar no wire-level
+                     presence, so "explicitly zero" and "omitted" are indistinguishable here, the same
+                     as for search_depth.
                   schema:
                     type: integer
                     format: uint32
@@ -504,7 +506,10 @@ components:
                     type: string
                     description: |-
                         next_page_token continues the search past this page. Set only on the final
-                         chunk of the stream; empty means there are no more pages. See
+                         chunk of the stream. Empty means there are no more pages, but only when the
+                         backend actually supports pagination; a backend that does not (SearchCapabilities
+                         .paginated false) always returns an empty token here, even when matches remain,
+                         and serves a single page capped at page_size or search_depth. See
                          TraceQueryParameters.pagination.
             description: |-
                 Response chunk for FindTraceSummaries. A single RPC call may yield multiple
@@ -548,17 +553,16 @@ components:
                     type: string
             description: Operation encapsulates information about operation.
         jaeger.api_v3.Pagination:
-            required:
-                - pageSize
             type: object
             properties:
                 pageSize:
                     type: integer
                     description: |-
                         page_size bounds the number of results in one page. When zero it falls back to
-                         search_depth (and search_depth's own default). Required whenever Pagination is
-                         sent at all: a Pagination with no page_size is meaningless, so the caller must
-                         send it explicitly, even as zero, rather than omit it.
+                         search_depth (and search_depth's own default), the same relationship search_depth
+                         itself documents. Not marked required: proto3 gives a plain scalar no wire-level
+                         presence, so "explicitly zero" and "omitted" are indistinguishable here, the same
+                         as for search_depth.
                     format: uint32
                 pageToken:
                     type: string

--- a/swagger/api_v3/query_service.openapi.yaml
+++ b/swagger/api_v3/query_service.openapi.yaml
@@ -171,6 +171,27 @@ paths:
                      This field is optional.
                   schema:
                     type: boolean
+                - name: query.pagination.pageSize
+                  in: query
+                  description: |-
+                    page_size bounds the number of results in one page. When zero it falls back to
+                     search_depth (and search_depth's own default). Required whenever Pagination is
+                     sent at all: a Pagination with no page_size is meaningless, so the caller must
+                     send it explicitly, even as zero, rather than omit it.
+                  schema:
+                    type: integer
+                    format: uint32
+                - name: query.pagination.pageToken
+                  in: query
+                  description: |-
+                    page_token continues a previous search. Empty starts a new one. The value is
+                     opaque: clients MUST treat it as an uninterpreted cursor and echo back exactly
+                     what the server returned, without inspecting or modifying it. Because this field
+                     is a protobuf string, the server MUST encode the token as valid UTF-8 text (for
+                     example, unpadded base64url of the underlying cursor bytes). A token is only
+                     valid for the same query that produced it.
+                  schema:
+                    type: string
                 - name: query.filter
                   in: query
                   description: Structured query filter as a URL-encoded JSON object (a Call expression). See RFC 0005 §6.
@@ -301,6 +322,27 @@ paths:
                      This field is optional.
                   schema:
                     type: boolean
+                - name: query.pagination.pageSize
+                  in: query
+                  description: |-
+                    page_size bounds the number of results in one page. When zero it falls back to
+                     search_depth (and search_depth's own default). Required whenever Pagination is
+                     sent at all: a Pagination with no page_size is meaningless, so the caller must
+                     send it explicitly, even as zero, rather than omit it.
+                  schema:
+                    type: integer
+                    format: uint32
+                - name: query.pagination.pageToken
+                  in: query
+                  description: |-
+                    page_token continues a previous search. Empty starts a new one. The value is
+                     opaque: clients MUST treat it as an uninterpreted cursor and echo back exactly
+                     what the server returned, without inspecting or modifying it. Because this field
+                     is a protobuf string, the server MUST encode the token as valid UTF-8 text (for
+                     example, unpadded base64url of the underlying cursor bytes). A token is only
+                     valid for the same query that produced it.
+                  schema:
+                    type: string
                 - name: query.filter
                   in: query
                   description: Structured query filter as a URL-encoded JSON object (a Call expression). See RFC 0005 §6.
@@ -458,6 +500,12 @@ components:
                     type: array
                     items:
                         $ref: '#/components/schemas/jaeger.api_v3.TraceSummary'
+                nextPageToken:
+                    type: string
+                    description: |-
+                        next_page_token continues the search past this page. Set only on the final
+                         chunk of the stream; empty means there are no more pages. See
+                         TraceQueryParameters.pagination.
             description: |-
                 Response chunk for FindTraceSummaries. A single RPC call may yield multiple
                  chunks, each carrying one or more summaries, mirroring the chunked streaming
@@ -499,6 +547,31 @@ components:
                 spanKind:
                     type: string
             description: Operation encapsulates information about operation.
+        jaeger.api_v3.Pagination:
+            required:
+                - pageSize
+            type: object
+            properties:
+                pageSize:
+                    type: integer
+                    description: |-
+                        page_size bounds the number of results in one page. When zero it falls back to
+                         search_depth (and search_depth's own default). Required whenever Pagination is
+                         sent at all: a Pagination with no page_size is meaningless, so the caller must
+                         send it explicitly, even as zero, rather than omit it.
+                    format: uint32
+                pageToken:
+                    type: string
+                    description: |-
+                        page_token continues a previous search. Empty starts a new one. The value is
+                         opaque: clients MUST treat it as an uninterpreted cursor and echo back exactly
+                         what the server returned, without inspecting or modifying it. Because this field
+                         is a protobuf string, the server MUST encode the token as valid UTF-8 text (for
+                         example, unpadded base64url of the underlying cursor bytes). A token is only
+                         valid for the same query that produced it.
+            description: |-
+                Pagination asks for one page of results and, on continuation, says where the
+                 previous page stopped.
         jaeger.api_v3.ServiceSummary:
             required:
                 - name
@@ -609,6 +682,17 @@ components:
                          Over the HTTP GET binding it is a URL-encoded JSON object; in a request body
                          it is the structured Call. For example, the filter http.status_code == 500 is
                          {"op":"eq","args":[{"attr":{"key":"http.status_code"}},{"scalar":{"value":"500"}}]}
+                pagination:
+                    allOf:
+                        - $ref: '#/components/schemas/jaeger.api_v3.Pagination'
+                    description: |-
+                        pagination requests a paginated search. When this field is absent the search
+                         behaves exactly as today: one page bounded by search_depth, no continuation.
+
+                         Only FindTraceSummaries returns a continuation token (FindTraceSummariesResponse.
+                         next_page_token); FindTraces streams opentelemetry.proto.trace.v1.TracesData, which has
+                         no room for one, so page_size still bounds a FindTraces call but the call itself cannot
+                         be resumed through this field.
             description: |-
                 Query parameters to find traces.
 


### PR DESCRIPTION
## Which problem is this PR solving?

This is M1 of the implementation roadmap in [RFC 0014: Search Result Pagination](https://github.com/jaegertracing/jaeger/blob/main/docs/rfc/0014-search-result-pagination.md#11-implementation-roadmap): "Proto foundation (jaeger-idl)." It follows the discussion on [jaeger#8961](https://github.com/jaegertracing/jaeger/pull/8961), an earlier RFC covering the same problem that was closed in favor of RFC 0014.

## Description of the changes

Adds the proto fields RFC 0014 §4 and §6 specify, additive only:

- `proto/api_v3/query_service.proto`: new `Pagination` message (`page_size`, `page_token`); `TraceQueryParameters.pagination` field; `FindTraceSummariesResponse.next_page_token` field.
- `proto/storage/v2/trace_storage.proto`: same `Pagination` message shape (duplicated per RFC 0014 §6, since `jaeger.storage.v2` does not import `jaeger.api_v3`); `TraceQueryParameters.pagination` field; `next_page_token` on both `FindTraceIDsResponse` and `FindTraceSummariesResponse`.
- `proto/storage/v2/capabilities.proto`: `SearchCapabilities.paginated` bool field, zero-value false per the existing capability pattern, so every backend that predates the field reports "cannot paginate."

Field numbers differ from RFC 0014's illustrative examples because RFC 0005's structured-filter fields landed on the same messages since the RFC was written:

- api_v3 `TraceQueryParameters.pagination` = 11 (field 10 is already `filter`), matches the RFC's example.
- storage/v2 `TraceQueryParameters.pagination` = 10, not the RFC's illustrative 9 (field 9 is already `filter` there; `search_depth` is 8).
- `SearchCapabilities.paginated` = 4, not the RFC's illustrative 2 (fields 1-3 are already `without_service_name`, `same_span_conjunction`, `filter`).

All changes are additive; no existing field numbers or behavior change.

## How was this change tested?

Verified with `make proto-api-v3-all` and `make proto-storage-all` against the `jaegertracing/protobuf:0.5.1` container: all four edited messages compile cleanly and generate the expected Go types (`Pagination{PageSize, PageToken}`, `NextPageToken`, `Paginated bool`) at the field numbers listed above.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/jaegertracing/jaeger-idl/blob/main/CONTRIBUTING.md)
- [x] All commits are signed (`git commit -s`)