### PR TITLE
fix(query): Refuse only inline case-folding flags

### DIFF
--- a/query/expression/v1/validate.go
+++ b/query/expression/v1/validate.go
@@ -468,7 +468,67 @@ func validatePattern(pattern string) error {
 	if err != nil {
 		return fmt.Errorf("operator %q takes a pattern in RE2 syntax: %w", OpRegex, err)
 	}
+	if hasInlineCaseFolding(pattern) {
+		return fmt.Errorf("operator %q matches case-sensitively, so a pattern cannot use an inline case-folding flag", OpRegex)
+	}
 	return checkPortable(parsed)
+}
+
+// hasInlineCaseFolding reports whether a pattern contains an unescaped inline
+// case-folding flag, e.g. (?i) or (?i:...).
+//
+// The check is lexical because Go's regexp parser folds two-element case
+// classes like [aA] or (a|A) into a FoldCase AST node, destroying the
+// distinction between a case class (which is portable and supported by
+// storage engines) and an inline flag group (which backends like Elasticsearch
+// cannot honor).
+func hasInlineCaseFolding(pattern string) bool {
+	inClass := false
+	for i := 0; i < len(pattern); i++ {
+		switch pattern[i] {
+		case '\\':
+			if i+1 < len(pattern) {
+				if pattern[i+1] == 'Q' {
+					// \Q...\E quotes literal text until \E or end of string.
+					i += 2
+					for i < len(pattern) {
+						if pattern[i] == '\\' && i+1 < len(pattern) && pattern[i+1] == 'E' {
+							i++
+							break
+						}
+						i++
+					}
+					continue
+				}
+				i++
+			}
+		case '[':
+			if !inClass {
+				inClass = true
+			}
+		case ']':
+			if inClass {
+				inClass = false
+			}
+		case '(':
+			if !inClass && i+1 < len(pattern) && pattern[i+1] == '?' {
+				i += 2
+				if i < len(pattern) && pattern[i] == 'P' {
+					continue
+				}
+				sawMinus := false
+				for i < len(pattern) && pattern[i] != ':' && pattern[i] != ')' {
+					if pattern[i] == '-' {
+						sawMinus = true
+					} else if (pattern[i] == 'i' || pattern[i] == 'I') && !sawMinus {
+						return true
+					}
+					i++
+				}
+			}
+		}
+	}
+	return false
 }
 
 // checkPortable refuses the constructs the backends this lowers to do not all have. Elasticsearch,
@@ -483,9 +543,6 @@ func checkPortable(re *syntax.Regexp) error {
 	}
 	if re.Flags&syntax.NonGreedy != 0 {
 		return fmt.Errorf("operator %q asks whether the value matches, so a quantifier cannot be lazy", OpRegex)
-	}
-	if re.Flags&syntax.FoldCase != 0 {
-		return fmt.Errorf("operator %q matches case-sensitively, so a pattern cannot fold case", OpRegex)
 	}
 	for _, sub := range re.Sub {
 		if err := checkPortable(sub); err != nil {

--- a/query/expression/v1/validate_test.go
+++ b/query/expression/v1/validate_test.go
@@ -138,6 +138,90 @@ func TestValidateFilter_Accepts(t *testing.T) {
 			}},
 		},
 		{
+			name: "a regular expression with case classes",
+			filter: &Call{Op: OpRegex, Args: []Expression{
+				attr("http.route"),
+				&StringValue{Value: "[aA]bc"},
+			}},
+		},
+		{
+			name: "a regular expression with k/s case classes",
+			filter: &Call{Op: OpRegex, Args: []Expression{
+				attr("http.route"),
+				&StringValue{Value: "[kK]ilo[sS]pan"},
+			}},
+		},
+		{
+			name: "a regular expression with alternation case pair",
+			filter: &Call{Op: OpRegex, Args: []Expression{
+				attr("http.route"),
+				&StringValue{Value: "(a|A)bc"},
+			}},
+		},
+		{
+			name: "a regular expression with disabled case folding",
+			filter: &Call{Op: OpRegex, Args: []Expression{
+				attr("http.route"),
+				&StringValue{Value: "(?-i)abc"},
+			}},
+		},
+		{
+			name: "a regular expression with flag turned off after dot-all",
+			filter: &Call{Op: OpRegex, Args: []Expression{
+				attr("http.route"),
+				&StringValue{Value: "(?s-i)a"},
+			}},
+		},
+		{
+			name: "a regular expression with non-capturing group",
+			filter: &Call{Op: OpRegex, Args: []Expression{
+				attr("http.route"),
+				&StringValue{Value: "(?:ab)"},
+			}},
+		},
+		{
+			name: "a regular expression with named capture group",
+			filter: &Call{Op: OpRegex, Args: []Expression{
+				attr("http.route"),
+				&StringValue{Value: "(?P<name>a)"},
+			}},
+		},
+		{
+			name: "a regular expression with literal quote span",
+			filter: &Call{Op: OpRegex, Args: []Expression{
+				attr("http.route"),
+				&StringValue{Value: `\Q(?i)\E`},
+			}},
+		},
+		{
+			name: "a regular expression with unterminated literal quote span",
+			filter: &Call{Op: OpRegex, Args: []Expression{
+				attr("http.route"),
+				&StringValue{Value: `\Q(?i)`},
+			}},
+		},
+		{
+			name: "a regular expression with escaped flag sequence",
+			filter: &Call{Op: OpRegex, Args: []Expression{
+				attr("http.route"),
+				&StringValue{Value: `\(\?i\)`},
+			}},
+		},
+		{
+			name: "a regular expression with flag sequence inside character class",
+			filter: &Call{Op: OpRegex, Args: []Expression{
+				attr("http.route"),
+				&StringValue{Value: "[(?i)]"},
+			}},
+		},
+		{
+			name: "a regular expression with bracket class containing flag chars",
+			filter: &Call{Op: OpRegex, Args: []Expression{
+				attr("http.route"),
+				&StringValue{Value: "[?i(]"},
+			}},
+		},
+		{
 			name: "an ordered comparison of typed constants",
 			filter: &Call{Op: OpGte, Args: []Expression{
 				attr("http.response.size"),
@@ -443,9 +527,86 @@ func TestValidateFilter_Rejects(t *testing.T) {
 		},
 		{
 			name:        "a regular expression asking to fold case",
-			expectedErr: `operator "regex" matches case-sensitively, so a pattern cannot fold case`,
+			expectedErr: `operator "regex" matches case-sensitively, so a pattern cannot use an inline case-folding flag`,
 			filter: &Call{Op: OpRegex, Args: []Expression{
 				&FieldRef{Name: SpanFieldName, Level: LevelSpan}, &StringValue{Value: "(?i)get"},
+			}},
+		},
+		{
+			name:        "a regular expression with inline flag group",
+			expectedErr: `operator "regex" matches case-sensitively, so a pattern cannot use an inline case-folding flag`,
+			filter: &Call{Op: OpRegex, Args: []Expression{
+				&FieldRef{Name: SpanFieldName, Level: LevelSpan}, &StringValue{Value: "(?i:abc)"},
+			}},
+		},
+		{
+			name:        "a regular expression with combined inline flags",
+			expectedErr: `operator "regex" matches case-sensitively, so a pattern cannot use an inline case-folding flag`,
+			filter: &Call{Op: OpRegex, Args: []Expression{
+				&FieldRef{Name: SpanFieldName, Level: LevelSpan}, &StringValue{Value: "(?is)abc"},
+			}},
+		},
+		{
+			name:        "a regular expression with inline flags in other order",
+			expectedErr: `operator "regex" matches case-sensitively, so a pattern cannot use an inline case-folding flag`,
+			filter: &Call{Op: OpRegex, Args: []Expression{
+				&FieldRef{Name: SpanFieldName, Level: LevelSpan}, &StringValue{Value: "(?si)a"},
+			}},
+		},
+		{
+			name:        "a regular expression turning flag on then other off",
+			expectedErr: `operator "regex" matches case-sensitively, so a pattern cannot use an inline case-folding flag`,
+			filter: &Call{Op: OpRegex, Args: []Expression{
+				&FieldRef{Name: SpanFieldName, Level: LevelSpan}, &StringValue{Value: "(?i-s)a"},
+			}},
+		},
+		{
+			name:        "a regular expression with mid-pattern inline flag",
+			expectedErr: `operator "regex" matches case-sensitively, so a pattern cannot use an inline case-folding flag`,
+			filter: &Call{Op: OpRegex, Args: []Expression{
+				&FieldRef{Name: SpanFieldName, Level: LevelSpan}, &StringValue{Value: "a(?i)b"},
+			}},
+		},
+		{
+			name:        "a regular expression with mid-pattern inline flag group",
+			expectedErr: `operator "regex" matches case-sensitively, so a pattern cannot use an inline case-folding flag`,
+			filter: &Call{Op: OpRegex, Args: []Expression{
+				&FieldRef{Name: SpanFieldName, Level: LevelSpan}, &StringValue{Value: "x(?i:y)z"},
+			}},
+		},
+		{
+			name:        "a regular expression with nested inline flag group",
+			expectedErr: `operator "regex" matches case-sensitively, so a pattern cannot use an inline case-folding flag`,
+			filter: &Call{Op: OpRegex, Args: []Expression{
+				&FieldRef{Name: SpanFieldName, Level: LevelSpan}, &StringValue{Value: "((?i))"},
+			}},
+		},
+		{
+			name:        "a regular expression with bare inline flag",
+			expectedErr: `operator "regex" matches case-sensitively, so a pattern cannot use an inline case-folding flag`,
+			filter: &Call{Op: OpRegex, Args: []Expression{
+				&FieldRef{Name: SpanFieldName, Level: LevelSpan}, &StringValue{Value: "(?i)"},
+			}},
+		},
+		{
+			name:        "a regular expression with closed class followed by inline flag",
+			expectedErr: `operator "regex" matches case-sensitively, so a pattern cannot use an inline case-folding flag`,
+			filter: &Call{Op: OpRegex, Args: []Expression{
+				&FieldRef{Name: SpanFieldName, Level: LevelSpan}, &StringValue{Value: "[a-z](?i)"},
+			}},
+		},
+		{
+			name:        "a regular expression with POSIX class followed by inline flag",
+			expectedErr: `operator "regex" matches case-sensitively, so a pattern cannot use an inline case-folding flag`,
+			filter: &Call{Op: OpRegex, Args: []Expression{
+				&FieldRef{Name: SpanFieldName, Level: LevelSpan}, &StringValue{Value: "[[:alpha:]](?i)x"},
+			}},
+		},
+		{
+			name:        "a regular expression with escaped bracket class followed by inline flag",
+			expectedErr: `operator "regex" matches case-sensitively, so a pattern cannot use an inline case-folding flag`,
+			filter: &Call{Op: OpRegex, Args: []Expression{
+				&FieldRef{Name: SpanFieldName, Level: LevelSpan}, &StringValue{Value: `[\]](?i)x`},
 			}},
 		},
 		{


### PR DESCRIPTION
## Which problem is this PR solving

`checkPortable` refuses a pattern whose parsed AST carries `syntax.FoldCase`. Go's parser sets that when it collapses a case pair into a folded literal, so after parsing, `[aA]` and `(?i)a` are the same tree and both are refused. RFC 0005 §5.3 says the refusal is for "an inline case-folding flag", the flag rather than the class, so this brings the validator in line with what the RFC already says.

Two things I found while checking it. The refusal isn't consistent across the alphabet: of the 26 two-letter case classes, 24 are refused and `[kK]` and `[sS]` are accepted, because k and s have three-member fold orbits (U+212A, U+017F) that the parser can't collapse into a literal. And there's no spelling that gets through, `(a|A)`, `a|A`, `[A-Aa-a]` and `[\x61\x41]` all normalise to the same folded literal, so a caller wanting one letter in either case has no way to write it.

Elasticsearch serves the class correctly and doesn't serve the flag. Lowered as `.*(P).*` with `flags: NONE` on ES 8.19, `[aA]lpha` matches `alpha` and `Alpha`, while `(?i)alpha` matches nothing at all, including a document whose value is the literal text `(?i)alpha`. So the check was refusing what the backend answers exactly and keeping the one construct it can't honor.

## Description of the changes

The check is now lexical, for the same reason `perlShorthand` is: the parse destroys the distinction, so it has to happen before it. It skips escapes and `\Q...\E` spans, ignores anything inside a character class, treats `(?P` as a named group rather than a flag section, and refuses only when an `i` appears in a flag section before any `-`, so `(?-i)` and `(?s-i)` are fine.

Tests cover the traps that shape those rules: `\Q(?i)\E`, `\(\?i\)`, `[(?i)]`, `[a-z](?i)` where a closed class doesn't protect what follows, `(?P<n>a)`, and mid-pattern `a(?i)b`.

This needs a release plus a `go get` bump in jaeger before it has any effect there. Can send the bump once it's tagged.

## How was this change tested?

`make test-ci` and `make lint` pass. The new cases were checked against a real Elasticsearch 8.19 as well, to confirm the patterns this now admits are the ones the backend actually honors.

AI helped me write this. I ran everything above locally.
